### PR TITLE
Fix speaker ordering

### DIFF
--- a/cdhweb/events/models.py
+++ b/cdhweb/events/models.py
@@ -154,7 +154,7 @@ class Event(Displayable, RichText, AdminThumbMixin, ExcerptMixin):
         # convert dates to local timezone for display
         local_start = self.start_time.astimezone(local_tz)
         local_end = self.end_time.astimezone(local_tz)
-        start = ' '.join([local_start.strftime('%B %d'),
+        start = ' '.join([local_start.strftime('%b %d'),
                           local_start.strftime('%-I:%M')])
         start_ampm = local_start.strftime('%p')
         # include start am/pm if *different* from end
@@ -164,7 +164,7 @@ class Event(Displayable, RichText, AdminThumbMixin, ExcerptMixin):
         # include end month and day if *different* from start
         end_pieces = []
         if local_start.month != local_end.month:
-            end_pieces.append(local_end.strftime('%B %d'))
+            end_pieces.append(local_end.strftime('%b %d'))
         elif local_start.day != local_end.day:
             end_pieces.append(local_end.strftime('%d'))
         end_pieces.append(local_end.strftime('%-I:%M %p').lower())

--- a/cdhweb/events/tests.py
+++ b/cdhweb/events/tests.py
@@ -73,7 +73,7 @@ class TestEvent(TestCase):
         end = jan15 + timedelta(hours=1, minutes=30)
         event = Event(start_time=jan15, end_time=end)
         # start day month date time (no pm), end time (pm)
-        assert event.when() == '%s – %s' % (jan15.strftime('%B %d %-I:%M'),
+        assert event.when() == '%s – %s' % (jan15.strftime('%b %d %-I:%M'),
                                             end.strftime('%-I:%M %p').lower())
 
         # same day, starting in am and ending in pm
@@ -81,14 +81,14 @@ class TestEvent(TestCase):
         # should include am on start time
         # NOTE: %-I should be equivalent to %I with lstrip('0')
         assert event.when() == '%s %s – %s' % \
-            (event.start_time.strftime('%B %d %-I:%M'),
+            (event.start_time.strftime('%b %d %-I:%M'),
              event.start_time.strftime('%p').lower(),
              end.strftime('%I:%M %p').lstrip('0').lower())
 
         # different days, same month
         event.start_time = jan15 + timedelta(days=1)
         assert event.when() == '%s – %s %s' % \
-            (event.start_time.strftime('%B %d %-I:%M'),
+            (event.start_time.strftime('%b %d %-I:%M'),
              end.strftime('%d %-I:%M'), end.strftime('%p').lower())
 
         # different timezone should get localized to current timezone
@@ -100,13 +100,13 @@ class TestEvent(TestCase):
         end = jan15 + timedelta(days=35)
         event = Event(start_time=jan15, end_time=end)
         # month name should display
-        assert end.strftime('%B') in event.when()
+        assert end.strftime('%b') in event.when()
 
         # different months, same day
         feb15 = datetime(2015, 2, 15, hour=16, tzinfo=timezone.get_default_timezone())
         event = Event(start_time=jan15, end_time=feb15)
-        assert event.start_time.strftime('%B %d') in event.when()
-        assert event.end_time.strftime('%B %d') in event.when()
+        assert event.start_time.strftime('%b %d') in event.when()
+        assert event.end_time.strftime('%b %d') in event.when()
 
     def test_duration(self):
         jan15 = datetime(2015, 1, 15, hour=16, tzinfo=timezone.get_default_timezone())

--- a/cdhweb/people/fixtures/test_people_data.json
+++ b/cdhweb/people/fixtures/test_people_data.json
@@ -496,6 +496,24 @@
       }
     },
     {
+        "model": "auth.user",
+        "pk": 12,
+        "fields": {
+          "password": "",
+          "last_login": null,
+          "is_superuser": false,
+          "username": "rms",
+          "first_name": "Richard",
+          "last_name": "Stallman",
+          "email": "",
+          "is_staff": false,
+          "is_active": true,
+          "date_joined": "2018-09-04T15:00:13.753Z",
+          "groups": [],
+          "user_permissions": []
+        }
+    },
+    {
       "model": "people.profile",
       "pk": 1,
       "fields": {
@@ -824,6 +842,39 @@
         "thumb": "",
         "attachments": []
       }
+    },
+    {
+        "model": "people.profile",
+        "pk": 11,
+        "fields": {
+          "keywords_string": "",
+          "site": 1,
+          "title": "Richard M. Stallman",
+          "slug": "rms",
+          "_meta_title": null,
+          "description": "Richard M. Stallman",
+          "gen_description": true,
+          "created": "2018-09-04T15:00:14.099Z",
+          "updated": "2018-09-04T15:01:02.713Z",
+          "status": 2,
+          "publish_date": "2018-09-04T15:00:14.097Z",
+          "expiry_date": null,
+          "short_url": null,
+          "in_sitemap": true,
+          "user": 12,
+          "is_staff": false,
+          "education": "",
+          "bio": "",
+          "phone_number": "",
+          "office_location": "",
+          "job_title": "President",
+          "department": "",
+          "institution": "Free Software Foundation",
+          "pu_status": "external",
+          "image": "",
+          "thumb": "",
+          "attachments": []
+        }
     },
     {
       "model": "people.position",

--- a/cdhweb/people/models.py
+++ b/cdhweb/people/models.py
@@ -243,6 +243,14 @@ class ProfileQuerySet(PublishedQuerySetMixin):
         return self.filter(user__event__end_time__gte=timezone.now(),
                            user__event__status=CONTENT_STATUS_PUBLISHED).distinct()
 
+    def order_by_event(self):
+        '''Order by earliest published event associated with profile.'''
+        return self.annotate(
+            earliest_event=models.Case(
+                models.When(user__event__status=CONTENT_STATUS_PUBLISHED,
+                            then='user__event__start_time'))
+            ).order_by('earliest_event')
+
     def order_by_position(self):
         '''order by job title sort order and then by start date'''
         # annotate to avoid duplicates in the queryset due to multiple positions

--- a/cdhweb/people/models.py
+++ b/cdhweb/people/models.py
@@ -246,9 +246,9 @@ class ProfileQuerySet(PublishedQuerySetMixin):
     def order_by_event(self):
         '''Order by earliest published event associated with profile.'''
         return self.annotate(
-            earliest_event=models.Case(
+            earliest_event=models.Min(models.Case(
                 models.When(user__event__status=CONTENT_STATUS_PUBLISHED,
-                            then='user__event__start_time'))
+                            then='user__event__start_time')))
             ).order_by('earliest_event')
 
     def order_by_position(self):

--- a/cdhweb/people/templates/people/snippets/profile_card.html
+++ b/cdhweb/people/templates/people/snippets/profile_card.html
@@ -3,7 +3,7 @@
     {% if profile.thumb %}style="background-image:url('{{ MEDIA_URL }}{{ profile.thumb }}')"{% endif %}>
     {% if show_events and profile.user.event_set.published.upcoming %} {# link to event, if speaker has upcoming one #}
         {% with profile.user.event_set.published.upcoming.first as event %}
-        <a class="external event" title="event listing" href="{{ event.get_absolute_url }}"></a>
+        <a class="external event" title="{{ event.title }}" href="{{ event.get_absolute_url }}"></a>
         {% endwith %}
     {% endif %}
     {% with profile.user.profile_url as profile_url %} {# local or external profile, if available #}


### PR DESCRIPTION
- upcoming speakers are sorted by soonest upcoming published event
- past speakers are sorted by most recent year in which they had a published event
## dev notes
- adds a customizable `get_past_profiles()` method to `ProfileListView` so that past portion of queryset can be queried or sorted independently; defaults to `NOT current` logic
- adds an `order_by_event()` method to `ProfileQuerySet` that orders by event start time, filtering on published events