### PR TITLE
enhancement/draft page indicator (#157)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
 - sudo chown root /opt/google/chrome/chrome-sandbox
 - sudo chmod 4755 /opt/google/chrome/chrome-sandbox
 - mysql -u root -e "create database test";  # load and run site for pa11y to check
+- mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql
 - python manage.py migrate
 - python manage.py loaddata pa11y_test_site
 - python manage.py compress -f -v0 # compress static assets
@@ -30,6 +31,8 @@ before_script:
 script:
 - py.test --cov=cdhweb
 - npm run pa11y
+services:
+- mysql
 after_success:
 - codecov
 notifications:

--- a/cdhweb/resources/tests/test_templates.py
+++ b/cdhweb/resources/tests/test_templates.py
@@ -1,0 +1,30 @@
+from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import AnonymousUser
+from django.shortcuts import render
+from mezzanine.pages.models import RichTextPage
+from mezzanine.core.models import CONTENT_STATUS_DRAFT, CONTENT_STATUS_PUBLISHED
+
+
+class TestDraftPageIndicator(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_draft_page(self):
+        # body should have classes "richtextpage draft"
+        page = RichTextPage(title="my draft page", status=CONTENT_STATUS_DRAFT)
+        page.save()
+        request = self.factory.get(page.get_absolute_url())
+        request.user = AnonymousUser()
+        response = render(request, 'pages/richtextpage.html', {'page': page})
+        self.assertContains(response, '<body class="richtextpage draft">')
+
+    def test_published_page(self):
+        # body should just have class "richtextpage"
+        page = RichTextPage(title="my draft page",
+                            status=CONTENT_STATUS_PUBLISHED)
+        page.save()
+        request = self.factory.get(page.get_absolute_url())
+        request.user = AnonymousUser()
+        response = render(request, 'pages/richtextpage.html', {'page': page})
+        self.assertContains(response, '<body class="richtextpage">')

--- a/sitemedia/scss/site.scss
+++ b/sitemedia/scss/site.scss
@@ -1683,7 +1683,40 @@ body.richtextpage {
 			}
 		}
 
-	}
+    }
+    
+    /* triangular indicator/watermark for draft pages */
+    &.draft {
+        &::before,
+        &::after {
+            position: absolute;
+            right: 0;
+            top: 65px;
+            z-index: 1;
+        }
+
+        &::before {
+            content: '';
+            width: 0;
+            height: 0;
+            border-left: 150px solid transparent;
+            border-top: 150px solid $cdh-blue;
+        }
+
+        &::after {
+            width: 150px;
+            height: 150px;
+            color: white;
+            content: '\0270F   draft';
+            font-family: $font-stack-headline;
+            transform: rotate(45deg);
+            text-align: center;
+            margin-top: 10px;
+            margin-right: 10px;
+            font-size: 32px;
+            text-shadow: 1px 1px 1px black;
+        }
+    }
 }
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -59,9 +59,7 @@
         </div>
     </header>
     {% include 'snippets/test_banner.html' %}
-
-  </div>
-</div>
+    
     {% block content %}
         {% block content-header %}
         {% endblock %}

--- a/templates/pages/richtextpage.html
+++ b/templates/pages/richtextpage.html
@@ -1,6 +1,6 @@
 {% extends "pages/richtextpage.html" %}
 
-{% block bodyattrs %}class="richtextpage"{% endblock %}
+{% block bodyattrs %}class="richtextpage{% if not page.published %} draft{% endif %}"{% endblock %}
 
 
 {% block main %}


### PR DESCRIPTION
- adds a check in the `richtextpage.html` template that adds a `draft` class to the body if the page is a draft
- adds styles to `site.scss` to draw a triangular mark over the page to indicate a draft