### PR TITLE
a11y/main nav kbd

### DIFF
--- a/sitemedia/js/local.js
+++ b/sitemedia/js/local.js
@@ -59,51 +59,51 @@ $(document).ready(function () {
     // keybindings for primary nav (people, projects, research, etc.)
     $('.primary-nav > li > a')
         .keydown(function (e) {
-            switch (e.which) {
-                case 35: { // home
+            switch (e.key) {
+                case 'Home': {
                     e.preventDefault()
                     hideCard(e.target.id)
                     var firstCard = $('.primary-nav > li > a').first()
                     firstCard.focus()
                     break
                 }
-                case 36: { // end
+                case 'End': {
                     e.preventDefault()
                     hideCard(e.target.id)
                     var lastCard = $('.primary-nav > li > a').last()
                     lastCard.focus()
                     break
                 }
-                case 37: { // left arrow
+                case 'ArrowLeft': {
                     e.preventDefault()
                     hideCard(e.target.id)
                     var prevCard = $(e.target).parent().prev('li').find('a')
                     prevCard.focus()
                     break
                 }
-                case 38: { // up arrow
+                case 'ArrowUp': {
                     e.preventDefault()
                     showCard(e.target.id)
                     var lastLink = $('#' + e.target.id + '-secondary > li > a').last()
                     lastLink.focus()
                     break
                 }
-                case 39: { // right arrow
+                case 'ArrowRight': {
                     e.preventDefault()
                     hideCard(e.target.id)
                     var nextCard = $(e.target).parent().next('li').find('a')
                     nextCard.focus()
                     break
                 }
-                case 40: { // down arrow
+                case 'ArrowDown': {
                     e.preventDefault()
                     showCard(e.target.id)
                     var firstLink = $('#' + e.target.id + '-secondary > li > a').first()
                     firstLink.focus()
                     break
                 }
-                case 13: // enter
-                case 32: { // spacebar
+                case 'Enter':
+                case ' ': { // spacebar
                     e.preventDefault()
                     e.target.click()
                     break
@@ -114,9 +114,9 @@ $(document).ready(function () {
     // keybindings for secondary nav (flyout cards)
     $('.secondary-nav > li > a')
         .keydown(function (e) {
-            switch (e.which) {
-                case 38: // up arrow
-                case 27: { // escape
+            switch (e.key) {
+                case 'ArrowUp':
+                case 'Escape': {
                     e.preventDefault()
                     var parentMenu = $(e.target).parents('.secondary-nav').get()[0]
                     var parentMenuName = parentMenu.id.split('-secondary')[0]
@@ -124,31 +124,33 @@ $(document).ready(function () {
                     $('#' + parentMenuName).focus()
                     break
                 }
-                case 35: { // home
+                case 'Home': {
                     e.preventDefault()
-                    var firstLink = $(e.target).parent().first('li').find('a')
+                    var parentMenu = $(e.target).parents('.secondary-nav').first()
+                    var firstLink = parentMenu.find('li').first().find('a')
                     firstLink.focus()
                     break
                 }
-                case 36: { // end
+                case 'End': {
                     e.preventDefault()
-                    var lastLink = $(e.target).parent().last('li').find('a')
+                    var parentMenu = $(e.target).parents('.secondary-nav').first()
+                    var lastLink = parentMenu.find('li').last().find('a')
                     lastLink.focus()
                     break
                 }
-                case 37: { // left arrow
+                case 'ArrowLeft': {
                     e.preventDefault()
                     var prevLink = $(e.target).parent().prev('li').find('a').first()
                     prevLink.focus()
                     break
                 }
-                case 39: { // right arrow
+                case 'ArrowRight': {
                     e.preventDefault()
                     var nextLink = $(e.target).parent().next('li').find('a').first()
                     nextLink.focus()
                     break
                 }
-                case 40: { // down arrow
+                case 'ArrowDown': {
                     e.preventDefault()
                     var associatedList = $(e.target).siblings('.tertiary-nav')
                     if (associatedList.length > 0) {
@@ -156,8 +158,8 @@ $(document).ready(function () {
                     }
                     break
                 }
-                case 13: // enter
-                case 32: { // spacebar
+                case 'Enter':
+                case ' ': { // spacebar
                     e.preventDefault()
                     e.target.click()
                     break
@@ -168,8 +170,8 @@ $(document).ready(function () {
     // keybindings for tertiary nav (lists on cards)
     $('.tertiary-nav > li > a')
         .keydown(function (e) {
-            switch (e.which) {
-                case 27: { // escape
+            switch (e.key) {
+                case 'Escape': {
                     e.preventDefault()
                     var parentCard = $(e.target).parents('.secondary-nav').get()[0]
                     var parentCardName = parentCard.id.split('-secondary')[0]
@@ -177,26 +179,28 @@ $(document).ready(function () {
                     $('#' + parentCardName).focus()
                     break
                 }
-                case 35: { // home
+                case 'Home': {
                     e.preventDefault()
-                    var firstLink = $(e.target).parent().first('li').find('a')
+                    var parentMenu = $(e.target).parents('.tertiary-nav').first()
+                    var firstLink = parentMenu.find('li').first().find('a')
                     firstLink.focus()
                     break
                 }
-                case 36: { // end
+                case 'End': {
                     e.preventDefault()
-                    var lastLink = $(e.target).parent().last('li').find('a')
+                    var parentMenu = $(e.target).parents('.tertiary-nav').first()
+                    var lastLink = parentMenu.find('li').last().find('a')
                     lastLink.focus()
                     break
                 }
-                case 37: {// left arrow
+                case 'ArrowLeft': {
                     e.preventDefault()
                     var parentSecondary = $(e.target).parents('.tertiary-nav').siblings('a')
                     var prevSecondary = parentSecondary.parent().prev('li').find('a').first()
                     prevSecondary.focus()
                     break
                 }
-                case 38: { // up arrow
+                case 'ArrowUp': {
                     e.preventDefault()
                     var prevLink = $(e.target).parent().prev('li').find('a')
                     if (prevLink.length > 0) {
@@ -209,21 +213,21 @@ $(document).ready(function () {
                     }
                     break
                 }
-                case 39: { // right arrow
+                case 'ArrowRight': {
                     e.preventDefault()
                     var parentSecondary = $(e.target).parents('.tertiary-nav').siblings('a')
                     var nextSecondary = parentSecondary.parent().next('li').find('a').first()
                     nextSecondary.focus()
                     break
                 }
-                case 40: { // down arrow
+                case 'ArrowDown': {
                     e.preventDefault()
                     var nextLink = $(e.target).parent().next('li').find('a')
                     nextLink.focus()
                     break
                 }
-                case 13: // enter
-                case 32: { // spacebar
+                case 'Enter':
+                case ' ': { // spacebar
                     e.preventDefault()
                     e.target.click()
                     break

--- a/sitemedia/js/local.js
+++ b/sitemedia/js/local.js
@@ -1,11 +1,11 @@
-$(document).ready(function(){
+$(document).ready(function () {
     var $ribbon = $('.ribbon');
     if ($ribbon) {
         var faded = sessionStorage.getItem('fade-test-banner', true);
-        if (! faded) {
+        if (!faded) {
             $('.ribbon-box').removeClass('fade');
         }
-        $ribbon.on('click',function(){
+        $ribbon.on('click', function () {
             $('.ribbon-box').addClass('fade');
             sessionStorage.setItem('fade-test-banner', true);
         });
@@ -18,22 +18,18 @@ $(document).ready(function(){
       those, leave it as is.
       If the scroll is up by 5 px, bring the menu back.
     */
-    $(window).scroll(function()
-    {
+    $(window).scroll(function () {
         scrolled = $(document).scrollTop();
         if (scrolled - scroll > 25 && scrolled > scroll && scrolled >
-            90)
-        {
+            90) {
             $('header').addClass('hidden');
             hideCards()
         }
-        else if (scrolled > scroll)
-        {
+        else if (scrolled > scroll) {
             // Do nothing since the scroll was either
             // too high or not 'enough'
         }
-        else if (scrolled < scroll && scroll - scrolled > 5)
-        {
+        else if (scrolled < scroll && scroll - scrolled > 5) {
             $('header').removeClass('hidden');
         }
 
@@ -42,7 +38,7 @@ $(document).ready(function(){
     });
 
 
-    $('.menu-toggle').on('click', function(e){
+    $('.menu-toggle').on('click', function (e) {
         e.preventDefault();
         // toggle footer to act as main mobile nav
         $('footer').toggleClass('mobile-nav');
@@ -50,20 +46,126 @@ $(document).ready(function(){
         // swap hamburger icon with close icon
         $(e.target).toggleClass('fa-bars').toggleClass('fa-times')
     });
-    $('a.toggle').on('click', function(e){
+    $('a.toggle').on('click', function (e) {
         $(this).parent().toggleClass('open');
         $(this).parent().find('.submenu').toggle();
     });
 
+
+    /*
+     * Main navigation
+     */
+
+    // keybindings for primary nav
+    // see https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-1/menubar-1.html
+    $('.primary-nav > li > a')
+        .keydown(function (e) {
+            switch (e.which) {
+                case 35: { // home
+                    hideCard(e.target.id)
+                    var firstCard = $('.primary-nav > li > a').first()
+                    firstCard.focus()
+                    break
+                }
+                case 36: { // end
+                    hideCard(e.target.id)
+                    var lastCard = $('.primary-nav > li > a').last()
+                    lastCard.focus()
+                    break
+                }
+                case 37: { // left arrow
+                    hideCard(e.target.id)
+                    var prevCard = $(e.target).parent().prev('li').find('a')
+                    prevCard.focus()
+                    break
+                }
+                case 38: { // up arrow
+                    e.preventDefault()
+                    showCard(e.target.id)
+                    var lastLink = $('#' + e.target.id + '-secondary > li > a').last()
+                    lastLink.focus()
+                    break
+                }
+                case 39: { // right arrow
+                    hideCard(e.target.id)
+                    var nextCard = $(e.target).parent().next('li').find('a')
+                    nextCard.focus()
+                    break
+                }
+                case 40: { // down arrow
+                    e.preventDefault()
+                    showCard(e.target.id)
+                    var firstLink = $('#' + e.target.id + '-secondary > li > a').first()
+                    firstLink.focus()
+                    break
+                }
+                case 13: // enter
+                case 32: { // spacebar
+                    $(e.target).click()
+                    break
+                }
+            }
+        })
+
+    // keybindings for secondary nav (cards)
+    // see https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-1/menubar-1.html
+    $('.secondary-nav > li > a')
+        .keydown(function (e) {
+            switch (e.which) {
+                case 27: { // escape
+                    var parentMenu = $(e.target).parents('.secondary-nav').get()[0]
+                    var parentMenuName = parentMenu.id.split('-secondary')[0]
+                    hideCard(parentMenuName)
+                    $('#' + parentMenuName).focus()
+                }
+                case 35: { // home
+                    var firstLink = $(e.target).parent().first('li').find('a')
+                    firstLink.focus()
+                    break
+                }
+                case 36: { // end
+                    var lastLink = $(e.target).parent().last('li').find('a')
+                    lastLink.focus()
+                    break
+                }
+                case 37: { // left arrow
+                    var prevLink = $(e.target).parent().prev('li').find('a')
+                    prevLink.focus()
+                    break
+                }
+                case 38: { // up arrow
+                    e.preventDefault()
+                    break
+                }
+                case 39: { // right arrow
+                    var nextLink = $(e.target).parent().next('li').find('a')
+                    nextLink.focus()
+                    break
+                }
+                case 40: { // down arrow
+                    e.preventDefault()
+                    break
+                }
+                case 13: // enter
+                case 32: { // spacebar
+                    $(e.target).click()
+                    break
+                }
+            }
+        })
+
     // show nav card on mouseover for main menu entry
-    $('.primary-nav a').mouseenter(function(e) {
-        showCard(e.target.id)
-    })
+    $('.primary-nav a')
+        .mouseenter(function (e) { showCard(e.target.id) })
 
     // hide all nav cards when we leave the nav
-    $('.nav-wrap').mouseleave(function() {
-        hideCards()
-    })
+    $('.nav-wrap')
+        .mouseleave(function () { hideCards() })
+
+    function hideCard(id) {
+        $('.nav-card.menu-' + id).hide()
+        $('#' + id).attr('aria-expanded', false)
+    }
 
     function showCard(id) {
         hideCards() // hide others
@@ -73,14 +175,14 @@ $(document).ready(function(){
 
     function hideCards() {
         $('.primary-nav a').attr('aria-expanded', false)
-        $('.nav-card').hide()   
+        $('.nav-card').hide()
     }
 
     /*
      * Homepage carousel
      */
 
-    var changeSlide = function(toIndex) {
+    var changeSlide = function (toIndex) {
         // show the slide
         $('#carousel .post-update.active').removeClass('active')
         $('#carousel .post-update').eq(toIndex).addClass('active')
@@ -89,8 +191,8 @@ $(document).ready(function(){
         $('#post-controls a div').eq(toIndex).addClass('active')
     }
 
-    $('#post-controls a').each(function(i, button) {
-        $(button).click(function() {
+    $('#post-controls a').each(function (i, button) {
+        $(button).click(function () {
             changeSlide(i)
             // restart the autoplay "timer" from zero
             clearInterval(playerID)
@@ -102,8 +204,8 @@ $(document).ready(function(){
     // thus hovering would "freeze" the slideshow
 
     // autoplay function
-    var startAutoplay = function() {
-        return setInterval(function(){
+    var startAutoplay = function () {
+        return setInterval(function () {
             var activeIndex = $('#post-controls a div.active').data('index')
             var newIndex = (activeIndex + 1) % $('#post-controls a').length
             changeSlide(newIndex)

--- a/sitemedia/js/local.js
+++ b/sitemedia/js/local.js
@@ -62,44 +62,40 @@ $(document).ready(function () {
             switch (e.key) {
                 case 'Home': {
                     e.preventDefault()
-                    hideCard(e.target.id)
-                    var firstCard = $('.primary-nav > li > a').first()
-                    firstCard.focus()
+                    var firstLink = $('.primary-nav > li > a').first()
+                    firstLink.focus()
                     break
                 }
                 case 'End': {
                     e.preventDefault()
-                    hideCard(e.target.id)
-                    var lastCard = $('.primary-nav > li > a').last()
-                    lastCard.focus()
+                    var lastLink = $('.primary-nav > li > a').last()
+                    lastLink.focus()
                     break
                 }
                 case 'ArrowLeft': {
                     e.preventDefault()
-                    hideCard(e.target.id)
-                    var prevCard = $(e.target).parent().prev('li').find('a')
-                    prevCard.focus()
+                    var prevLink = $(e.target).parent().prev('li').find('a')
+                    prevLink.focus()
                     break
                 }
                 case 'ArrowUp': {
                     e.preventDefault()
                     showCard(e.target.id)
-                    var lastLink = $('#' + e.target.id + '-secondary > li > a').last()
-                    lastLink.focus()
+                    var lastCardLink = $('#' + e.target.id + '-secondary > li > a').last()
+                    lastCardLink.focus()
                     break
                 }
                 case 'ArrowRight': {
                     e.preventDefault()
-                    hideCard(e.target.id)
-                    var nextCard = $(e.target).parent().next('li').find('a')
-                    nextCard.focus()
+                    var nextLink = $(e.target).parent().next('li').find('a')
+                    nextLink.focus()
                     break
                 }
                 case 'ArrowDown': {
                     e.preventDefault()
                     showCard(e.target.id)
-                    var firstLink = $('#' + e.target.id + '-secondary > li > a').first()
-                    firstLink.focus()
+                    var firstCardLink = $('#' + e.target.id + '-secondary > li > a').first()
+                    firstCardLink.focus()
                     break
                 }
                 case 'Enter':
@@ -120,7 +116,7 @@ $(document).ready(function () {
                     e.preventDefault()
                     var parentMenu = $(e.target).parents('.secondary-nav').get()[0]
                     var parentMenuName = parentMenu.id.split('-secondary')[0]
-                    hideCard(parentMenuName)
+                    hideCards()
                     $('#' + parentMenuName).focus()
                     break
                 }
@@ -175,7 +171,7 @@ $(document).ready(function () {
                     e.preventDefault()
                     var parentCard = $(e.target).parents('.secondary-nav').get()[0]
                     var parentCardName = parentCard.id.split('-secondary')[0]
-                    hideCard(parentCardName)
+                    hideCards()
                     $('#' + parentCardName).focus()
                     break
                 }
@@ -242,11 +238,6 @@ $(document).ready(function () {
     // hide all nav cards when we leave the nav
     $('.nav-wrap')
         .mouseleave(function () { hideCards() })
-
-    function hideCard(id) {
-        $('.nav-card.menu-' + id).hide()
-        $('#' + id).attr('aria-expanded', false)
-    }
 
     function showCard(id) {
         hideCards() // hide others

--- a/sitemedia/js/local.js
+++ b/sitemedia/js/local.js
@@ -56,24 +56,26 @@ $(document).ready(function () {
      * Main navigation
      */
 
-    // keybindings for primary nav
-    // see https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-1/menubar-1.html
+    // keybindings for primary nav (people, projects, research, etc.)
     $('.primary-nav > li > a')
         .keydown(function (e) {
             switch (e.which) {
                 case 35: { // home
+                    e.preventDefault()
                     hideCard(e.target.id)
                     var firstCard = $('.primary-nav > li > a').first()
                     firstCard.focus()
                     break
                 }
                 case 36: { // end
+                    e.preventDefault()
                     hideCard(e.target.id)
                     var lastCard = $('.primary-nav > li > a').last()
                     lastCard.focus()
                     break
                 }
                 case 37: { // left arrow
+                    e.preventDefault()
                     hideCard(e.target.id)
                     var prevCard = $(e.target).parent().prev('li').find('a')
                     prevCard.focus()
@@ -87,6 +89,7 @@ $(document).ready(function () {
                     break
                 }
                 case 39: { // right arrow
+                    e.preventDefault()
                     hideCard(e.target.id)
                     var nextCard = $(e.target).parent().next('li').find('a')
                     nextCard.focus()
@@ -101,54 +104,128 @@ $(document).ready(function () {
                 }
                 case 13: // enter
                 case 32: { // spacebar
-                    $(e.target).click()
+                    e.preventDefault()
+                    e.target.click()
                     break
                 }
             }
         })
 
-    // keybindings for secondary nav (cards)
-    // see https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-1/menubar-1.html
+    // keybindings for secondary nav (flyout cards)
     $('.secondary-nav > li > a')
         .keydown(function (e) {
             switch (e.which) {
+                case 38: // up arrow
                 case 27: { // escape
+                    e.preventDefault()
                     var parentMenu = $(e.target).parents('.secondary-nav').get()[0]
                     var parentMenuName = parentMenu.id.split('-secondary')[0]
                     hideCard(parentMenuName)
                     $('#' + parentMenuName).focus()
+                    break
                 }
                 case 35: { // home
+                    e.preventDefault()
                     var firstLink = $(e.target).parent().first('li').find('a')
                     firstLink.focus()
                     break
                 }
                 case 36: { // end
+                    e.preventDefault()
                     var lastLink = $(e.target).parent().last('li').find('a')
                     lastLink.focus()
                     break
                 }
                 case 37: { // left arrow
-                    var prevLink = $(e.target).parent().prev('li').find('a')
+                    e.preventDefault()
+                    var prevLink = $(e.target).parent().prev('li').find('a').first()
                     prevLink.focus()
                     break
                 }
-                case 38: { // up arrow
-                    e.preventDefault()
-                    break
-                }
                 case 39: { // right arrow
-                    var nextLink = $(e.target).parent().next('li').find('a')
+                    e.preventDefault()
+                    var nextLink = $(e.target).parent().next('li').find('a').first()
                     nextLink.focus()
                     break
                 }
                 case 40: { // down arrow
                     e.preventDefault()
+                    var associatedList = $(e.target).siblings('.tertiary-nav')
+                    if (associatedList.length > 0) {
+                        associatedList.find('a').first().focus()
+                    }
                     break
                 }
                 case 13: // enter
                 case 32: { // spacebar
-                    $(e.target).click()
+                    e.preventDefault()
+                    e.target.click()
+                    break
+                }
+            }
+        })
+
+    // keybindings for tertiary nav (lists on cards)
+    $('.tertiary-nav > li > a')
+        .keydown(function (e) {
+            switch (e.which) {
+                case 27: { // escape
+                    e.preventDefault()
+                    var parentCard = $(e.target).parents('.secondary-nav').get()[0]
+                    var parentCardName = parentCard.id.split('-secondary')[0]
+                    hideCard(parentCardName)
+                    $('#' + parentCardName).focus()
+                    break
+                }
+                case 35: { // home
+                    e.preventDefault()
+                    var firstLink = $(e.target).parent().first('li').find('a')
+                    firstLink.focus()
+                    break
+                }
+                case 36: { // end
+                    e.preventDefault()
+                    var lastLink = $(e.target).parent().last('li').find('a')
+                    lastLink.focus()
+                    break
+                }
+                case 37: {// left arrow
+                    e.preventDefault()
+                    var parentSecondary = $(e.target).parents('.tertiary-nav').siblings('a')
+                    var prevSecondary = parentSecondary.parent().prev('li').find('a').first()
+                    prevSecondary.focus()
+                    break
+                }
+                case 38: { // up arrow
+                    e.preventDefault()
+                    var prevLink = $(e.target).parent().prev('li').find('a')
+                    if (prevLink.length > 0) {
+                        prevLink.focus()
+                    }
+                    else {
+                        var parentMenu = $(e.target).parents('.tertiary-nav')
+                        var parentSecondary = parentMenu.siblings('a')
+                        parentSecondary.focus()
+                    }
+                    break
+                }
+                case 39: { // right arrow
+                    e.preventDefault()
+                    var parentSecondary = $(e.target).parents('.tertiary-nav').siblings('a')
+                    var nextSecondary = parentSecondary.parent().next('li').find('a').first()
+                    nextSecondary.focus()
+                    break
+                }
+                case 40: { // down arrow
+                    e.preventDefault()
+                    var nextLink = $(e.target).parent().next('li').find('a')
+                    nextLink.focus()
+                    break
+                }
+                case 13: // enter
+                case 32: { // spacebar
+                    e.preventDefault()
+                    e.target.click()
                     break
                 }
             }

--- a/sitemedia/scss/base/_navigation.scss
+++ b/sitemedia/scss/base/_navigation.scss
@@ -265,9 +265,7 @@ header.nav {
     .nav-main ul,
     .nav-card ul {
         /* add indicator for section of menu being viewed */
-        a:hover,
-        a:focus {
-            outline: none;
+        a:hover {
             border-bottom: 4px;
             border-bottom-color: $cdh-blue;
             border-bottom-style: solid;

--- a/sitemedia/scss/base/_navigation.scss
+++ b/sitemedia/scss/base/_navigation.scss
@@ -161,16 +161,6 @@ header.nav {
                     @media (max-width: $small-max-width) {
                         margin-bottom: 5px;
                     }
-
-                    &:hover {
-                        /* add indicator for section of menu being viewed */
-                        > a {
-                            border-bottom: 4px;
-                            border-bottom-color: $cdh-blue;
-                            border-bottom-style: solid;
-                        }
-
-                    }
                 }
 
                 > li > a {
@@ -269,6 +259,18 @@ header.nav {
             a {
                 color: $dark-grey;
             }
+        }
+    }
+    
+    .nav-main ul,
+    .nav-card ul {
+        /* add indicator for section of menu being viewed */
+        a:hover,
+        a:focus {
+            outline: none;
+            border-bottom: 4px;
+            border-bottom-color: $cdh-blue;
+            border-bottom-style: solid;
         }
     }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,7 +42,7 @@
 <body {% block bodyattrs %}{% endblock %}>
     <ul class="skip-links">
         <li><a href='#maincontent'>Skip to main content</a></li>
-        <li><a href='#footermenu' aria-label='Footer Menu'>Skip to footer</a></li>
+        <li><a href='#footermenu'>Skip to footer</a></li>
     </ul>
     <header class="nav">
         <div class="nav-wrap">
@@ -51,9 +51,7 @@
             </nav>
             <nav id='mainmenu'>
                 <a href='{% url 'home' %}' class='home-page'>
-                  <img
-                  alt='The Center for Digital Humanities @ Princeton'
-                  src='{% static "img/CDH_logo.svg" %}' />
+                  <img alt="home" src='{% static "img/CDH_logo.svg" %}' />
                 </a>
                 {% page_menu "snippets/primary_navigation.html" %}
             </nav>

--- a/templates/snippets/navigation_card.html
+++ b/templates/snippets/navigation_card.html
@@ -2,7 +2,7 @@
 {# secondary and tertiary naviation for the top-level of the site #}
 <div class="nav-card menu-{{ page.html_id }}">
     <div class="inner">
-        <ul id="{{ page.html_id }}-secondary" class="secondary-nav" role="menubar" aria-labelledby="{{ page.html_id }}">
+        <ul id="{{ page.html_id }}-secondary" class="secondary-nav" role="menu" aria-labelledby="{{ page.html_id }}">
         {% for page in page_branch %}
             {% if '1' in page.in_menus %} {# workaround pages_tags limitation: explicitly check for primary nav option #}
             <li role="none">
@@ -10,6 +10,7 @@
                     id="{{ page.html_id }}"
                     role="menuitem"
                     href="{{ page.get_absolute_url }}"
+                    tabindex="-1"
                     {% if page.has_children_in_menu %} aria-owns="{{ page.html_id }}-tertiary"{% endif %}
                     {% if page.is_current %} aria-current="page"{% endif %}>{{ page.title }}</a>
                 {% if page.has_children_in_menu %}

--- a/templates/snippets/primary_navigation.html
+++ b/templates/snippets/primary_navigation.html
@@ -6,14 +6,17 @@
         {# top-level pages #}
         {% for page in page_branch %}
             {% if page.in_menu %}
-            <li>
+            <li role="none">
                 <a
                     id="{{ page.html_id }}"
                     role="menuitem"
+                    href="{{ page.get_absolute_url }}"
+                    {% if forloop.first %} tabindex="0"{% else %} tabindex="-1"{% endif %}
+                    {% if page.has_childen_in_menu %}
                     aria-owns="{{ page.html_id }}-secondary"
                     aria-haspopup="true"
                     aria-expanded="false"
-                    href="{{ page.get_absolute_url }}"
+                    {% endif %}
                     {% if page.is_current_or_ascendant %} aria-current="page"{% endif %}>{{ page.title }}</a>
             </li>
             {% endif %}

--- a/templates/snippets/primary_navigation.html
+++ b/templates/snippets/primary_navigation.html
@@ -4,28 +4,28 @@
 <div class="nav-main">
     <ul class='primary-nav' role="menubar" aria-label="main navigation">
         {# top-level pages #}
-        {% for page in page_branch %}
+        {# first item will always be home ('/') #}
+        {% for page in page_branch|slice:"1:" %}
             {% if page.in_menu %}
             <li role="none">
-                {# first item will always be 'home', second item after that should be #}
-                {# tab-focusable (tabindex 0), all others only focusable via js (-1) #}
                 <a
                     id="{{ page.html_id }}"
                     role="menuitem"
                     href="{{ page.get_absolute_url }}"
-                    {% if forloop.counter == 2 %} tabindex="0"{% else %} tabindex="-1"{% endif %}
+                    {% if forloop.first %} tabindex="0"{% else %} tabindex="-1"{% endif %}
                     {% if page.has_childen_in_menu %}
                     aria-owns="{{ page.html_id }}-secondary"
                     aria-haspopup="true"
                     aria-expanded="false"
                     {% endif %}
-                    {% if page.is_current_or_ascendant %} aria-current="page"{% endif %}>{{ page.title }}</a>
+                    {% if page.is_current_or_ascendant %} aria-current="page"{% endif %}>{{ page.title }}
+                </a>
             </li>
             {% endif %}
         {% endfor %}
     </ul>
 </div>
-{% for page in page_branch %}
+{% for page in page_branch|slice:"1:" %}
     {% if page.has_children_in_menu %}
         {% page_menu page "snippets/navigation_card.html" %}
     {% endif %}

--- a/templates/snippets/primary_navigation.html
+++ b/templates/snippets/primary_navigation.html
@@ -7,11 +7,13 @@
         {% for page in page_branch %}
             {% if page.in_menu %}
             <li role="none">
+                {# first item will always be 'home', second item after that should be #}
+                {# tab-focusable (tabindex 0), all others only focusable via js (-1) #}
                 <a
                     id="{{ page.html_id }}"
                     role="menuitem"
                     href="{{ page.get_absolute_url }}"
-                    {% if forloop.first %} tabindex="0"{% else %} tabindex="-1"{% endif %}
+                    {% if forloop.counter == 2 %} tabindex="0"{% else %} tabindex="-1"{% endif %}
                     {% if page.has_childen_in_menu %}
                     aria-owns="{{ page.html_id }}-secondary"
                     aria-haspopup="true"

--- a/templates/snippets/tertiary_navigation.html
+++ b/templates/snippets/tertiary_navigation.html
@@ -1,12 +1,13 @@
 {% load pages_tags %}
 {# tertiary navigation, where applicable #}
-<ul id="{{ page.html_id }}-tertiary" class="tertiary-nav" role="menubar" aria-labelledby="{{ page.html_id }}">
+<ul id="{{ page.html_id }}-tertiary" class="tertiary-nav" aria-labelledby="{{ page.html_id }}">
     {% for page in page_branch %}
     {% if '1' in page.in_menus %} {# workaround pages_tags limitation: explicitly check for primary nav option #}
     <li role="none">
         <a
             role="menuitem"
             href="{{ page.get_absolute_url }}"
+            tabindex="-1"
             {% if page.is_current %} aria-current="page"{% endif %}>
             {{ page.title }}
         </a>


### PR DESCRIPTION
this adds keyboard controls for moving around the main navigation. it borrows from the [w3c nav menubar example](https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-1/menubar-1.html) where possible.

to use, <kbd>tab</kbd> to the main nav and skip past the cdh icon (home link) until the first item is focused (people). from here, use the below controls to operate the menu.

- <kbd>←</kbd> / <kbd>→</kbd> to move between items/lists
- <kbd>↓</kbd> / <kbd>↑</kbd> to enter/exit a list (open/close a nav card)
- <kbd>home</kbd> / <kbd>end</kbd> to jump to first/last item in a list
- <kbd>esc</kbd> to close the currently active nav card
- <kbd>space</kbd> / <kbd>enter</kbd> to click a currently focused link

note that we currently use the browser default visual focus indicator when navigating with the keyboard. this is so that it doesn't conflict with the active style, so that the user can see the active link (cdh-blue underline) as well as the focused link. it might be worth designing our own focus style to complement the active style in the future.

this solution is implemented using jQuery and definitely duplicates a lot of code - as part of the overhaul of cdh-web we will need to move the frontend pipeline to webpack, at which point we can revisit the code to pull it out into a class, use modern syntax (`let/const`), and remove the jQuery dependency.
