### PR TITLE
Include grad student project managers on student affiliates page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 before_script:
 - sudo chown root /opt/google/chrome/chrome-sandbox
 - sudo chmod 4755 /opt/google/chrome/chrome-sandbox
-- mysql -u root -e "create database test";  # load and run site for pa11y to check
+- mysql -u root -e "create database cdhweb";  # load and run site for pa11y to check
 - mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root mysql
 - python manage.py migrate
 - python manage.py loaddata pa11y_test_site

--- a/cdhweb/people/fixtures/test_people_data.json
+++ b/cdhweb/people/fixtures/test_people_data.json
@@ -113,6 +113,14 @@
         }
     },
     {
+        "model": "projects.role",
+        "pk": 2,
+        "fields": {
+            "title": "Project Manager",
+            "sort_order": 1
+        }
+    },
+    {
         "model": "people.title",
         "pk": 1,
         "fields": {
@@ -539,6 +547,24 @@
             "user_permissions": []
         }
     },
+     {
+        "model": "auth.user",
+        "pk": 14,
+        "fields": {
+            "password": "",
+            "last_login": null,
+            "is_superuser": false,
+            "username": "mary",
+            "first_name": "",
+            "last_name": "",
+            "email": "",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2018-08-30T18:43:22.973Z",
+            "groups": [],
+            "user_permissions": []
+        }
+    },
     {
         "model": "people.profile",
         "pk": 1,
@@ -936,6 +962,39 @@
         }
     },
     {
+        "model": "people.profile",
+        "pk": 14,
+        "fields": {
+            "keywords_string": "",
+            "site": 1,
+            "title": "Mary N.",
+            "slug": "mary",
+            "_meta_title": null,
+            "description": " ",
+            "gen_description": true,
+            "created": "2018-08-30T18:45:21.258Z",
+            "updated": "2018-08-30T18:45:21.258Z",
+            "status": 2,
+            "publish_date": "2018-08-30T18:45:21.258Z",
+            "expiry_date": null,
+            "short_url": null,
+            "in_sitemap": true,
+            "user": 14,
+            "is_staff": false,
+            "education": "",
+            "bio": "",
+            "phone_number": "",
+            "office_location": "",
+            "job_title": "",
+            "department": "",
+            "institution": "",
+            "pu_status": "graduate",
+            "image": "",
+            "thumb": "",
+            "attachments": []
+        }
+    },
+    {
         "model": "people.position",
         "pk": 1,
         "fields": {
@@ -1159,6 +1218,16 @@
             "user": 7,
             "grant": 3,
             "role": 1
+        }
+    },
+    {
+        "model": "projects.membership",
+        "pk": 4,
+        "fields": {
+            "project": 2,
+            "user": 14,
+            "grant": 3,
+            "role": 2
         }
     }
 ]

--- a/cdhweb/people/models.py
+++ b/cdhweb/people/models.py
@@ -350,15 +350,6 @@ class Profile(Displayable, AdminThumbMixin):
         return self.user.current_title
 
 
-def workshops_taught(user):
-    '''Return a QuerySet for the list of workshop events taught by a
-    particular user.'''
-    return user.event_set.filter(event_type__name='Workshop')
-
-# patch in to user for convenience  (may want to change)
-User.workshops_taught = workshops_taught
-
-
 class Position(DateRange):
     '''Through model for many-to-many relation between people
     and titles.  Adds start and end dates to the join table.'''

--- a/cdhweb/people/templates/people/snippets/profile_card.html
+++ b/cdhweb/people/templates/people/snippets/profile_card.html
@@ -12,21 +12,15 @@
         <div class="content">
             <p class="name">{{ profile.title }}</p> {# profile page title = person's name #}
             <div class="title">
-            {% with position=profile.user.positions.first %}
-                {% if show_cdh_position and position %} {# show position within the cdh #}
-                    <p>{% if not position.is_current %}{{ position.years }}{% if show_grant and profile.user.latest_grant %}{% else %}<br/>{% endif %}{% endif %}
-                    {# when showing both position and grant, if person has both omit line breaks #}
-                    {{ profile.user.positions.first.title|default:'' }}</p>
-                {% endif %}
-            {% endwith %}
             {# NOTE: right now, if someone has both grant and cdh staff role, both will show #}
             {% if show_grant %} {# display grant role #}
                 {% with grant=profile.user.latest_grant %}
                     {% if grant %}
                     {# NOTE: for unknown reasons, on qa these are not returned as date objects; handle either date or YYYY-MM-DD string#}
                         <p>{% if profile.first_start and profile.last_end %}
-                            {% firstof profile.first_start.year profile.first_start|slice:":4" %}–{% firstof profile.last_end.year profile.last_end|slice:":4" %}{% if show_cdh_position and profile.user.positions.first %}{% else %}<br/>{% endif %}
-                        {# when showing both position and grant, if person has both omit line breaks #}
+                            {% firstof profile.first_start.year profile.first_start|slice:":4" as start_year %}
+                            {% firstof profile.last_end.year profile.last_end|slice:":4" as end_year %}
+                            {{ start_year }}{% if start_year != end_year %}–{{ end_year }}{% endif %}
                         {% elif not grant.is_current %}{{ grant.years }}{% endif %}
                         {# special case for faculty fellowship display #}
                         {% if grant.grant_type.grant_type == 'Faculty Fellowship' %}Faculty Fellow{% else %}
@@ -34,6 +28,17 @@
                     {% endif %}
                 {% endwith %}
             {% endif %}
+            {% if profile.pm_start %}
+                {% if not profile.is_current %}{{ profile.pm_start.year }}–{{ profile.pm_end.year }}{% endif %}
+                Project Manager
+            {% endif %}
+            {% with position=profile.user.positions.first %}
+                {% if show_cdh_position and position %} {# show position within the cdh #}
+                    <p>{% if not position.is_current %}{{ position.years }}{% endif %}
+                    {# when showing both position and grant, if person has both omit line breaks #}
+                    {{ profile.user.positions.first.title|default:'' }}</p>
+                {% endif %}
+            {% endwith %}
             {% if show_affiliation and profile.institution %} {# show institutional affiliation #}
                 {{ profile.institution }}<br/>
             {% endif %}

--- a/cdhweb/people/tests.py
+++ b/cdhweb/people/tests.py
@@ -184,6 +184,28 @@ class ProfileQuerySetTest(TestCase):
         grant.save()
         assert grad_pi.profile in Profile.objects.current()
 
+        # grad pm on current grant based on dates
+        grad_pm = Person.objects.get(username='mary')
+        assert grad_pm.profile in Profile.objects.current()
+        # check status override
+        pm_membership = grad_pm.membership_set.first()
+        pm_membership.status_override = 'past'
+        pm_membership.save()
+        # past should make not current even though grant is active
+        assert grad_pm.profile not in Profile.objects.current()
+        grant = grad_pm.membership_set.first().grant
+        # set end in the past
+        grant.end_date = date.today() - timedelta(days=30)
+        grant.save()
+        # remove the status override
+        pm_membership.status_override = ""
+        pm_membership.save()
+        assert grad_pm.profile not in Profile.objects.current()
+        # override to set as current even though grant is past
+        pm_membership.status_override = 'current'
+        pm_membership.save()
+        assert grad_pm.profile in Profile.objects.current()
+
     def test_order_by_position(self):
         director = Person.objects.get(username='Meredith')
         staff = Person.objects.get(username='staff')

--- a/cdhweb/people/tests.py
+++ b/cdhweb/people/tests.py
@@ -236,15 +236,19 @@ class ProfileQuerySetTest(TestCase):
         grad = Person.objects.get(username='grad')
         undergrad = Person.objects.get(username='undergrad')
         grad_pi = Person.objects.get(username='tom')
+        grad_pm = Person.objects.get(username='mary')
 
         assert staffer.profile not in Profile.objects.student_affiliates()
         assert grad.profile in Profile.objects.student_affiliates()
         assert undergrad.profile in Profile.objects.student_affiliates()
         assert grad_pi.profile in Profile.objects.student_affiliates()
+        assert grad_pm.profile in Profile.objects.student_affiliates()
 
-        # grad pi affiliation based on project membership
+        # grad pi & pm affiliation based on project membership
         grad_pi.membership_set.all().delete()
+        grad_pm.membership_set.all().delete()
         assert grad_pi.profile not in Profile.objects.student_affiliates()
+        assert grad_pm.profile not in Profile.objects.student_affiliates()
 
     def test_faculty_affiliates(self):
         # faculty person who is also project director
@@ -297,7 +301,7 @@ class ProfileQuerySetTest(TestCase):
         # no error for non-grantees
         Profile.objects.filter(user__membership__isnull=True).grant_years()
 
-        annotated = Profile.objects.filter(user__membership__isnull=False) \
+        annotated = Profile.objects.filter(user__membership__role__title='Project Director') \
                                    .grant_years()
         for profile in annotated:
             grants = Grant.objects.filter(membership__user=profile.user)

--- a/cdhweb/people/views.py
+++ b/cdhweb/people/views.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.db.models import Max
+from django.db.models import Max, Q, Case, When, Value
 from django.db.models.functions import Coalesce, Greatest
 from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
@@ -20,7 +20,7 @@ class ProfileMixinView(object):
     def get_queryset(self):
         # use displayable manager to find published profiles only
         # (or draft profiles for logged in users with permission to view)
-        return Profile.objects.published() # TODO: published(for_user=self.request.user)
+        return Profile.objects.published()  # TODO: published(for_user=self.request.user)
 
 
 class ProfileDetailView(ProfileMixinView, DetailView, LastModifiedMixin):
@@ -30,10 +30,12 @@ class ProfileDetailView(ProfileMixinView, DetailView, LastModifiedMixin):
         return super().get_queryset().staff()
 
     def get_context_data(self, *args, **kwargs):
-        context = super(ProfileDetailView, self).get_context_data(*args, **kwargs)
+        context = super(ProfileDetailView, self).get_context_data(
+            *args, **kwargs)
 
         # retrieve 3 most recent published blog posts with the current user as author
-        recent_posts = BlogPost.objects.filter(users__id=self.object.user.id).published()[:3]
+        recent_posts = BlogPost.objects.filter(
+            users__id=self.object.user.id).published()[:3]
 
         # also set object as page for common page display functionality
         context.update({
@@ -43,7 +45,7 @@ class ProfileDetailView(ProfileMixinView, DetailView, LastModifiedMixin):
         })
         if self.object.thumb:
             context['preview_image'] = absolutize_url(''.join([settings.MEDIA_URL,
-                str(self.object.thumb)]))
+                                                               str(self.object.thumb)]))
 
         return context
 
@@ -96,7 +98,7 @@ class ProfileListView(ProfileMixinView, ListView, LastModifiedListMixin):
             'past': past,
             'title': self.page_title,
             'past_title': self.past_title,
-            'current_title': self.current_title or self.page_title, # use main title as default
+            'current_title': self.current_title or self.page_title,  # use main title as default
             'archive_nav_urls': [
                 ('Staff', reverse('people:staff')),
                 ('Postdoctoral Fellows', reverse('people:postdocs')),
@@ -170,17 +172,23 @@ class StudentListView(ProfileListView):
 
     def get_past_profiles(self):
         # show most recent first based on grant or position end date
-
-        # order by most recent grant end date and then position
-        # end date (if a student ever has a staff position *after*
-        # working on a grant this will use the wrong date)
-
-        # NOTE: Greatest would be better than Coalesce, but on mysql
-        # it returns None of any values are null
+        # NOTE the use of Case/When here is to avoid Greatest() returning NULL
+        # if any of its arguments are NULL, which is mysql behavior:
+        # https://docs.djangoproject.com/en/2.2/ref/models/database-functions/#django.db.models.functions.Greatest
+        # see also the django docs on conditional aggregation:
+        # https://docs.djangoproject.com/en/1.11/ref/models/conditional-expressions/#conditional-aggregation
         return super().get_past_profiles() \
-            .annotate(most_recent=Coalesce(
-                Max('user__membership__grant__end_date'),
-                Max('user__positions__end_date')
+            .annotate(most_recent=Greatest(
+                Case(
+                    When(user__membership__grant__end_date__isnull=False,
+                         then=Max('user__membership__grant__end_date')),
+                    default=Value('0')
+                ),
+                Case(
+                    When(user__positions__end_date__isnull=False,
+                         then=Max('user__positions__end_date')),
+                    default=Value('0')
+                )
             )) \
             .order_by('-most_recent')
 

--- a/cdhweb/people/views.py
+++ b/cdhweb/people/views.py
@@ -149,6 +149,11 @@ class PostdocListView(ProfileListView):
         # we only care about current position, grant doesn't matter
         return self.object_list.current_position()
 
+    def get_past_profiles(self):
+        # show most recent first
+        return super().get_past_profiles()\
+            .order_by('-user__positions__end_date')
+
 
 class StudentListView(ProfileListView):
     '''Display current and past graduate fellows, graduate and undergraduate
@@ -158,7 +163,16 @@ class StudentListView(ProfileListView):
 
     def get_queryset(self):
         # filter to just students
-        return super().get_queryset().student_affiliates().grant_years()
+        return super().get_queryset().student_affiliates() \
+            .grant_years().project_manager_years()
+
+    def get_past_profiles(self):
+        # show most recent first
+        return super().get_past_profiles()\
+            .order_by('-user__positions__end_date')
+
+    # def get_past_profiles(self):
+    #     return super().get_past_profiles.order_by()
 
 
 class FacultyListView(ProfileListView):

--- a/ci/testsettings.py
+++ b/ci/testsettings.py
@@ -8,7 +8,7 @@ import os
 # immediately.
 
 # NOTE: setting debug = true to avoid pa11y-ci timeouts
-DEBUG = True
+DEBUG = False
 
 DATABASES = {
     'default': {

--- a/ci/testsettings.py
+++ b/ci/testsettings.py
@@ -11,10 +11,18 @@ import os
 DEBUG = True
 
 DATABASES = {
-    "default": {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'cdhweb.db'
-    }
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'cdhweb.db',
+        'USER': 'root',
+        'PASSWORD': '',
+        'HOST': '127.0.0.1',
+        'PORT': '',
+        'OPTIONS': {
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+            'read_default_file': '~travis/.my.cnf'
+        },
+    },
 }
 
 # required with django 1.11 when debug is false, even for tests

--- a/ci/testsettings.py
+++ b/ci/testsettings.py
@@ -13,7 +13,7 @@ DEBUG = True
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'cdhweb.db',
+        'NAME': 'cdhweb',
         'USER': 'root',
         'PASSWORD': '',
         'HOST': '127.0.0.1',
@@ -37,4 +37,3 @@ COMPRESS_ROOT = os.path.join(BASE_DIR, 'sitemedia')
 
 # run a full compress before e2e/a11y tests to serve statically
 COMPRESS_OFFLINE = True
-

--- a/sitemedia/scss/site.scss
+++ b/sitemedia/scss/site.scss
@@ -216,8 +216,8 @@ article.landing-page {
 		    @media (max-width: $small-max-width) {
                 padding-top: 88px;
             }
-              
-            text-shadow: 0 0 50px rgba(0, 0, 0, 0.5); 
+
+            text-shadow: 0 0 50px rgba(0, 0, 0, 0.5);
 		}
 		a.home {
 			color: $cdh-blue;
@@ -1374,8 +1374,16 @@ $event-card-img-height: 240px;
 	    	}
 	    }
 	}
+
+
 	p {
 		margin: 0 auto 50px;
+	}
+
+	&.card {
+		p {
+			margin: 0 auto;
+		}
 	}
 
     .bio,
@@ -1686,7 +1694,7 @@ body.richtextpage {
 		}
 
     }
-    
+
     /* triangular indicator/watermark for draft pages */
     &.draft {
         &::before,


### PR DESCRIPTION
- include grad student project managers in student affiliates page
- honor new status override flags for student affiliates page current/alum if they are there because of a grant (project director or project manager)
- reorder student affiliate alumni section so that most recent students are listed first