### PR TITLE
Display project grant history summary on project detail page

### DIFF
--- a/cdhweb/projects/admin.py
+++ b/cdhweb/projects/admin.py
@@ -90,7 +90,7 @@ class GrantMemberInline(admin.TabularInline):
 
 class GrantAdmin(admin.ModelAdmin):
     list_display = ('project', 'grant_type', 'start_date', 'end_date')
-    list_filter = ('start_date', 'end_date')
+    list_filter = ('start_date', 'end_date', 'grant_type')
     date_hierarchy = 'start_date'
     search_fields = ('project__title', 'grant_type__grant_type',
                      'start_date', 'end_date', 'project__long_description',
@@ -98,12 +98,14 @@ class GrantAdmin(admin.ModelAdmin):
                      'membership__user__username', 'membership__user__first_name',
                      'membership__user__last_name')
 
+    inlines = [GrantMemberInline]
+    # override model ordering to show most recent first
+    ordering = ['-start_date', 'project']
+
     def get_form(self, request, obj=None, **kwargs):
         # save object reference for filtering grants in membership Inline
         request.object = obj
         return super(GrantAdmin, self).get_form(request, obj, **kwargs)
-
-    inlines = [GrantMemberInline]
 
 
 class MembershipAdmin(admin.ModelAdmin):

--- a/cdhweb/projects/admin.py
+++ b/cdhweb/projects/admin.py
@@ -90,6 +90,7 @@ class GrantMemberInline(admin.TabularInline):
 
 class GrantAdmin(admin.ModelAdmin):
     list_display = ('project', 'grant_type', 'start_date', 'end_date')
+    list_filter = ('start_date', 'end_date')
     date_hierarchy = 'start_date'
     search_fields = ('project__title', 'grant_type__grant_type',
                      'start_date', 'end_date', 'project__long_description',

--- a/cdhweb/projects/models.py
+++ b/cdhweb/projects/models.py
@@ -151,11 +151,11 @@ class Grant(DateRange):
     grant_type = models.ForeignKey(GrantType)
 
     class Meta:
-        ordering = ['project', '-start_date']
+        ordering = ['start_date', 'project']
 
     def __str__(self):
-        return '%s: %s (%s-%s)' % (self.project.title, self.grant_type.grant_type,
-                                   self.start_date.year, self.end_date.year if self.end_date else '')
+        return '%s: %s (%s)' % (self.project.title, self.grant_type.grant_type,
+                                self.years)
 
 
 # fixme: where does resource type go, for associated links?

--- a/cdhweb/projects/models.py
+++ b/cdhweb/projects/models.py
@@ -150,6 +150,9 @@ class Grant(DateRange):
     project = models.ForeignKey(Project)
     grant_type = models.ForeignKey(GrantType)
 
+    class Meta:
+        ordering = ['project', '-start_date']
+
     def __str__(self):
         return '%s: %s (%s-%s)' % (self.project.title, self.grant_type.grant_type,
                                    self.start_date.year, self.end_date.year if self.end_date else '')

--- a/cdhweb/projects/templates/projects/project_detail.html
+++ b/cdhweb/projects/templates/projects/project_detail.html
@@ -51,16 +51,16 @@
     <img src="{{ MEDIA_URL }}{{ project.image }}"/>
     {% endif %}
     {{ project.long_description|safe }}
+    {% if project.grant_set.exists %}
     <section class="grant-history">
         <h2>CDH Grant History</h2>
-        {% if project.grant_set.count > 0 %}
         <ul>
-            {% for grant in project.grant_set.all %}
-            <li>{{ grant.years }} - {{ grant.grant_type }}</li>
+            {% for grant in project.grant_set.reverse %}
+            <li>{{ grant.years }} {{ grant.grant_type }}</li>
             {% endfor %}
         </ul>
-        {% endif %}
     </section>
+    {% endif %}
 </div>
 
 </div>

--- a/cdhweb/projects/templates/projects/project_detail.html
+++ b/cdhweb/projects/templates/projects/project_detail.html
@@ -51,6 +51,16 @@
     <img src="{{ MEDIA_URL }}{{ project.image }}"/>
     {% endif %}
     {{ project.long_description|safe }}
+    <section class="grant-history">
+        <h2>CDH Grant History</h2>
+        {% if project.grant_set.count > 0 %}
+        <ul>
+            {% for grant in project.grant_set.all %}
+            <li>{{ grant.years }} - {{ grant.grant_type }}</li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+    </section>
 </div>
 
 </div>

--- a/cdhweb/projects/tests.py
+++ b/cdhweb/projects/tests.py
@@ -301,8 +301,8 @@ class TestGrant(TestCase):
         grant = Grant(project=proj, grant_type=grtype,
                       start_date=datetime(start_year, 1, 1),
                       end_date=datetime(end_year, 1, 1))
-        assert str(grant) == '%s: %s (2016-2017)' % (proj.title,
-                                                     grtype.grant_type)
+        assert str(grant) == '%s: %s (2016–2017)' % \
+            (proj.title, grtype.grant_type)
 
 
 class TestMembership(TestCase):
@@ -316,8 +316,8 @@ class TestMembership(TestCase):
                                      end_date=datetime(2017, 1, 1))
         user = get_user_model().objects.create(username='contributor')
         role = Role.objects.create(title='Data consultant', sort_order=1)
-        membership = Membership.objects.create(project=proj,
-                                               user=user, grant=grant, role=role)
+        membership = Membership.objects.create(
+            project=proj, user=user, grant=grant, role=role)
 
         assert str(membership) == '%s - %s on %s' % (user, role, grant)
 
@@ -442,7 +442,7 @@ class TestViews(TestCase):
                                        url=project_url)
 
         response = self.client.get(reverse('project:detail',
-                                           kwargs={'slug':  proj.slug}))
+                                           kwargs={'slug': proj.slug}))
         assert response.context['project'] == proj
         self.assertContains(response, escape(proj.title))
         self.assertContains(response, proj.short_description)
@@ -455,6 +455,18 @@ class TestViews(TestCase):
         for contributor in [contrib1, contrib2, contrib3]:
             self.assertContains(response, contributor.profile.title)
         self.assertContains(response, project_url)
+
+        # test grant dates displayed
+        self.assertContains(response, '<h2>CDH Grant History</h2>')
+        self.assertContains(response,
+                            '%s %s' % (grant.years, grant.grant_type))
+
+        # if for some reason a project has no grants, should not display grants
+        proj.grant_set.all().delete()
+        response = self.client.get(reverse('project:detail',
+                                           kwargs={'slug': proj.slug}))
+        self.assertNotContains(response, '<h2>CDH Grant History</h2>')
+
         # TODO: test large image included
 
 

--- a/sitemedia/scss/site.scss
+++ b/sitemedia/scss/site.scss
@@ -1276,9 +1276,30 @@ $event-card-img-height: 240px;
 		p {
 			margin-top: 0;
 		}
-	}
+    }
+    
+    .grant-history {
+        margin-top: 2rem;
 
+        @media (min-width: $large-min-width) {
+            margin-top: 4rem;
+        }
 
+        ul {
+            list-style: none;
+            padding: 0;
+            font-family: $font-stack-headline;
+            color: $dark-grey;
+        }
+
+        li {
+            padding: 0.25rem 0;
+
+            @media (min-width: $large-min-width) {
+                padding: 0.5rem 0;
+            }
+        }
+    }
 }
 
 


### PR DESCRIPTION
Tweaked your preliminary code slightly
- seemed more logical for default grant sort should be by date oldest to newest, so I changed that and use reverse for display on the template and override in the admin section
- dropped the extra dash (visually redundant since it's right next to a date range)
- added unit tests for the template change