### PR TITLE
set up wagtail

### DIFF
--- a/cdhweb/settings.py
+++ b/cdhweb/settings.py
@@ -108,6 +108,28 @@ RICHTEXT_ALLOWED_TAGS = ('a', 'abbr', 'acronym', 'address', 'area', 'article',
                         'textarea', 'tfoot', 'th', 'thead', 'tr', 'tt', '',
                         'ul', 'var', 'wbr')
 
+####################
+# WAGTAIL SETTINGS #
+####################
+
+# Human-readable name of your Wagtail site shown on login to the Wagtail admin.
+# https://docs.wagtail.io/en/latest/reference/settings.html#site-name
+WAGTAIL_SITE_NAME = 'CDH Website'
+
+# Wagtail sends email notifications when content is submitted for moderation,
+# and when the content is accepted or rejected.
+# https://docs.wagtail.io/en/latest/reference/settings.html#email-notifications
+WAGTAILADMIN_NOTIFICATION_FROM_EMAIL = 'admin@cdh.princeton.edu'
+WAGTAILADMIN_NOTIFICATION_USE_HTML = True
+
+# Tags are case-sensitive by default. In many cases the reverse is preferable.
+# https://docs.wagtail.io/en/latest/reference/settings.html#case-insensitive-tags
+TAGGIT_CASE_INSENSITIVE = True
+
+# Shows where a particular image, document or snippet is being used on your site.
+# Generates a query which may run slowly on sites with large numbers of pages.
+# https://docs.wagtail.io/en/latest/reference/settings.html#usage-for-images-documents-and-snippets
+WAGTAIL_USAGE_COUNT_ENABLED = True
 
 ########################
 # MAIN DJANGO SETTINGS #
@@ -305,7 +327,19 @@ INSTALLED_APPS = [
     # "mezzanine.twitter",
     # "mezzanine.accounts",
     # "mezzanine.mobile",
-    "taggit",
+    'wagtail.contrib.forms',
+    'wagtail.contrib.redirects',
+    'wagtail.embeds',
+    'wagtail.sites',
+    'wagtail.users',
+    'wagtail.snippets',
+    'wagtail.documents',
+    'wagtail.images',
+    'wagtail.search',
+    'wagtail.admin',
+    'wagtail.core',
+    'modelcluster',
+    'taggit',
     'adminsortable2',
     "compressor",
     "fullurl",
@@ -345,6 +379,8 @@ MIDDLEWARE = (
     # "mezzanine.core.middleware.SitePermissionMiddleware",
     "mezzanine.pages.middleware.PageMiddleware",
     "mezzanine.core.middleware.FetchFromCacheMiddleware",
+    'wagtail.core.middleware.SiteMiddleware',
+    'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 )
 
 # Store these package names here as they may change in the future since

--- a/cdhweb/settings.py
+++ b/cdhweb/settings.py
@@ -116,12 +116,6 @@ RICHTEXT_ALLOWED_TAGS = ('a', 'abbr', 'acronym', 'address', 'area', 'article',
 # https://docs.wagtail.io/en/latest/reference/settings.html#site-name
 WAGTAIL_SITE_NAME = 'CDH Website'
 
-# Wagtail sends email notifications when content is submitted for moderation,
-# and when the content is accepted or rejected.
-# https://docs.wagtail.io/en/latest/reference/settings.html#email-notifications
-WAGTAILADMIN_NOTIFICATION_FROM_EMAIL = 'admin@cdh.princeton.edu'
-WAGTAILADMIN_NOTIFICATION_USE_HTML = True
-
 # Tags are case-sensitive by default. In many cases the reverse is preferable.
 # https://docs.wagtail.io/en/latest/reference/settings.html#case-insensitive-tags
 TAGGIT_CASE_INSENSITIVE = True

--- a/cdhweb/urls.py
+++ b/cdhweb/urls.py
@@ -3,10 +3,14 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.i18n import i18n_patterns
+from django.conf.urls.static import serve
 from django.contrib import admin
 from django.contrib.sitemaps.views import sitemap
-from django.views.i18n import set_language
 from django.views.generic.base import RedirectView, TemplateView
+from django.views.i18n import set_language
+from wagtail.admin import urls as wagtailadmin_urls
+from wagtail.core import urls as wagtail_urls
+from wagtail.documents import urls as wagtaildocs_urls
 
 from cdhweb.blog.sitemaps import BlogPostSitemap
 from cdhweb.events.sitemaps import EventSitemap
@@ -74,10 +78,24 @@ urlpatterns += [
     # may complicate testing with pa11y-ci
     url(r"^sitemap\.xml$", sitemap, {'sitemaps': sitemaps}, name='sitemap'),
 
+    # wagtail paths
+    # NOTE temporarily make wagtail pages available at pages/ so that they can
+    # coexist with mezzanine urls
+    url(r'^cms/', include(wagtailadmin_urls)),
+    url(r'^documents/', include(wagtaildocs_urls)),
+    url(r'^pages/', include(wagtail_urls)),
+
     # let mezzanine handle everything else
     url("^", include("mezzanine.urls")),
-
 ]
+
+if settings.DEBUG:
+    # serve user-uploaded media in debug mode
+    urlpatterns += [
+        url(r'^media/(?P<path>.*)$', serve, {
+            'document_root': settings.MEDIA_ROOT,
+        }),
+    ]
 
 # Adds ``STATIC_URL`` to the context of error pages, so that error
 # pages can use JS, CSS and images.

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2,6 +2,7 @@
 
 Django>=1.11.15,<2.0
 pillow>=5.2.0
+wagtail<=2.3
 mezzanine<=4.3
 django-compressor
 django-compressor-autoprefixer

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,11 +1,11 @@
-{% load static pages_tags mezzanine_tags fullurl %}
+{% load static pages_tags mezzanine_tags fullurl wagtailuserbar %}
 <!DOCTYPE html>
 <html lang='en' xmlns:schema="http://schema.org/" prefix="og: http://ogp.me/ns# profile: http://ogp.me/ns/profile#" {% block headattrs %}{% endblock %}>
 <head>
     <meta charset='UTF-8'/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     {# Google Analytics recommends this implementation now #}
-    {% if INCLUDE_ANALYTICS %}
+    {% if INCLUDE_ANALYTICS and not request.is_preview %}
     <!-- Global Site Tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-87887700-1"></script>
     <script>
@@ -142,7 +142,7 @@
 
     </footer>
 
-
+    {% wagtailuserbar %}
 </body>
 
 </html>

--- a/templates/wagtailadmin/base.html
+++ b/templates/wagtailadmin/base.html
@@ -1,0 +1,7 @@
+{% extends 'wagtailadmin/base.html' %}
+{% load staticfiles %}
+
+{% block branding_logo %}
+<img src="{% static 'img/cdh-logo-assets/CDH_logo_white.svg' %}"
+    alt="CDH Website" width="100"/>
+{% endblock %} 

--- a/templates/wagtailadmin/login.html
+++ b/templates/wagtailadmin/login.html
@@ -1,0 +1,11 @@
+{% extends 'wagtailadmin/login.html' %}
+{% load static %}
+
+{% block extra_css %}
+  {{ block.super }}
+  <link type="text/css" rel="stylesheet" href="{% static 'pucas/pu-login.css' %}"/>
+{% endblock %}
+
+{% block above_login %}
+    {% include 'pucas/pu-cas-login.html' %}
+{% endblock %}


### PR DESCRIPTION
closes #183 

adds a few non-essential but useful configs like `TAGGIT_CASE_INSENSITIVE` and `WAGTAIL_USAGE_COUNT_ENABLED` that were suggested in the wagtail setup docs. also ports templates for the wagtail admin backend and login form from mep.