### PR TITLE
Use django-apptemplates to specify richtextpage template inheritance

### DIFF
--- a/cdhweb/settings.py
+++ b/cdhweb/settings.py
@@ -257,8 +257,12 @@ TEMPLATES = [
         "DIRS": [
             os.path.join(PROJECT_ROOT, "templates")
         ],
-        "APP_DIRS": True,
         "OPTIONS": {
+            'loaders': [
+                'apptemplates.Loader',
+                'django.template.loaders.filesystem.Loader',
+                'django.template.loaders.app_directories.Loader',
+            ],
             "context_processors": [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -15,3 +15,4 @@ python-dateutil
 icalendar
 attrdict
 django-fullurl
+django-apptemplates

--- a/templates/pages/richtextpage.html
+++ b/templates/pages/richtextpage.html
@@ -1,4 +1,4 @@
-{% extends "pages/richtextpage.html" %}
+{% extends "pages:pages/richtextpage.html" %}
 
 {% block bodyattrs %}class="richtextpage{% if not page.published %} draft{% endif %}"{% endblock %}
 


### PR DESCRIPTION
I can't reproduce the bug in my local dev (which I think was always one of the problems with trying to fix this one), but it occurred to me that using `django-apptemplates` might help — it lets us specify the package of the template we want to extend. 