### PR TITLE
add research co-PI role as project director (#204)

### DIFF
--- a/cdhweb/projects/models.py
+++ b/cdhweb/projects/models.py
@@ -9,6 +9,7 @@ from mezzanine.core.models import Displayable
 from mezzanine.utils.models import AdminThumbMixin, upload_to
 from taggit.managers import TaggableManager
 
+from cdhweb.people.models import Person
 from cdhweb.resources.models import (Attachment, DateRange, ExcerptMixin,
                                      PublishedQuerySetMixin, ResourceType)
 
@@ -68,7 +69,7 @@ class Project(Displayable, AdminThumbMixin, ExcerptMixin):
     cdh_built = models.BooleanField('CDH Built', default=False,
                                     help_text='Project built by CDH Development & Design team.')
 
-    members = models.ManyToManyField('people.Person', through='Membership')
+    members = models.ManyToManyField(Person, through='Membership')
     resources = models.ManyToManyField(ResourceType, through='ProjectResource')
 
     tags = TaggableManager(blank=True)
@@ -167,9 +168,6 @@ class Role(models.Model):
     sort_order = models.PositiveIntegerField(default=0, blank=False,
                                              null=False)
 
-    # roles that imply directorship over a grant
-    DIRECTOR_ROLES = ('Project Director', 'Co-PI: Research Lead')
-
     class Meta:
         ordering = ['sort_order']
 
@@ -180,7 +178,7 @@ class Role(models.Model):
 class Membership(models.Model):
     '''Project membership - joins project, grant, user, and role.'''
     project = models.ForeignKey(Project, on_delete=models.CASCADE)
-    user = models.ForeignKey('people.Person', on_delete=models.CASCADE)
+    user = models.ForeignKey(Person, on_delete=models.CASCADE)
     grant = models.ForeignKey(Grant, on_delete=models.CASCADE)
     role = models.ForeignKey(Role, on_delete=models.CASCADE)
 

--- a/cdhweb/projects/models.py
+++ b/cdhweb/projects/models.py
@@ -9,7 +9,6 @@ from mezzanine.core.models import Displayable
 from mezzanine.utils.models import AdminThumbMixin, upload_to
 from taggit.managers import TaggableManager
 
-from cdhweb.people.models import Person
 from cdhweb.resources.models import (Attachment, DateRange, ExcerptMixin,
                                      PublishedQuerySetMixin, ResourceType)
 
@@ -69,7 +68,7 @@ class Project(Displayable, AdminThumbMixin, ExcerptMixin):
     cdh_built = models.BooleanField('CDH Built', default=False,
                                     help_text='Project built by CDH Development & Design team.')
 
-    members = models.ManyToManyField(Person, through='Membership')
+    members = models.ManyToManyField('people.Person', through='Membership')
     resources = models.ManyToManyField(ResourceType, through='ProjectResource')
 
     tags = TaggableManager(blank=True)
@@ -159,11 +158,17 @@ class Grant(DateRange):
 
 # fixme: where does resource type go, for associated links?
 
+
+
+
 class Role(models.Model):
     '''A role on a project'''
     title = models.CharField(max_length=255, unique=True)
     sort_order = models.PositiveIntegerField(default=0, blank=False,
                                              null=False)
+
+    # roles that imply directorship over a grant
+    DIRECTOR_ROLES = ('Project Director', 'Co-PI: Research Lead')
 
     class Meta:
         ordering = ['sort_order']
@@ -175,7 +180,7 @@ class Role(models.Model):
 class Membership(models.Model):
     '''Project membership - joins project, grant, user, and role.'''
     project = models.ForeignKey(Project, on_delete=models.CASCADE)
-    user = models.ForeignKey(Person, on_delete=models.CASCADE)
+    user = models.ForeignKey('people.Person', on_delete=models.CASCADE)
     grant = models.ForeignKey(Grant, on_delete=models.CASCADE)
     role = models.ForeignKey(Role, on_delete=models.CASCADE)
 


### PR DESCRIPTION
see #204 

- adds `Role.DIRECTOR_ROLES` so that more than one role can be treated as directorship for the purpose of determining who is a CDH affiliate
- resolves some circular import issues