### PR TITLE
Remove grant year ranges from profile card display

### DIFF
--- a/cdhweb/people/templates/people/snippets/profile_card.html
+++ b/cdhweb/people/templates/people/snippets/profile_card.html
@@ -16,13 +16,7 @@
             {% if show_grant %} {# display grant role #}
                 {% with grant=profile.user.latest_grant %}
                     {% if grant %}
-                    {# NOTE: for unknown reasons, on qa these are not returned as date objects; handle either date or YYYY-MM-DD string#}
-                        <p>{% if profile.first_start and profile.last_end %}
-                        {# NOTE: not using start year because it creates incorrect display values; see issue 197 #}
-                            {% firstof profile.first_start.year profile.first_start|slice:":4" as start_year %}
-                            {% firstof profile.last_end.year profile.last_end|slice:":4" as end_year %}
-                            {{ end_year }}
-                        {% elif not grant.is_current %}{{ grant.years }}{% endif %}
+                        <p>{{ grant.years }}
                         {# special case for faculty fellowship display #}
                         {% if grant.grant_type.grant_type == 'Faculty Fellowship' %}Faculty Fellow{% else %}
                         {{ grant.grant_type }} Grant Recipient{% endif %}</p>

--- a/cdhweb/people/templates/people/snippets/profile_card.html
+++ b/cdhweb/people/templates/people/snippets/profile_card.html
@@ -18,9 +18,10 @@
                     {% if grant %}
                     {# NOTE: for unknown reasons, on qa these are not returned as date objects; handle either date or YYYY-MM-DD string#}
                         <p>{% if profile.first_start and profile.last_end %}
+                        {# NOTE: not using start year because it creates incorrect display values; see issue 197 #}
                             {% firstof profile.first_start.year profile.first_start|slice:":4" as start_year %}
                             {% firstof profile.last_end.year profile.last_end|slice:":4" as end_year %}
-                            {{ start_year }}{% if start_year != end_year %}–{{ end_year }}{% endif %}
+                            {{ end_year }}
                         {% elif not grant.is_current %}{{ grant.years }}{% endif %}
                         {# special case for faculty fellowship display #}
                         {% if grant.grant_type.grant_type == 'Faculty Fellowship' %}Faculty Fellow{% else %}

--- a/cdhweb/people/tests.py
+++ b/cdhweb/people/tests.py
@@ -282,8 +282,10 @@ class ProfileQuerySetTest(TestCase):
 
         # faculty person with co-PI: Research Lead should be affiliate
         co_pi = Person.objects.create(username='copi')
-        co_pi_profile = Profile.objects.create(user=co_pi, title="Co-PI", pu_status='fac')
-        co_pi_role, _created = Role.objects.get_or_create(title='Co-PI: Research Lead')
+        co_pi_profile = Profile.objects.create(
+            user=co_pi, title="Co-PI", pu_status='fac')
+        co_pi_role, _created = Role.objects.get_or_create(
+            title='Co-PI: Research Lead')
         s_co_grant = Grant.objects.get(pk=4)
         s_co = Project.objects.get(slug='sco')
         Membership.objects.create(
@@ -526,12 +528,12 @@ class TestViews(TestCase):
         response = self.client.get(reverse('people:affiliates'))
         assert fac.profile in response.context['current']
 
-        # should display name and date range from latest grant
+        # should display name and date from latest grant
         grant = fac.latest_grant
-        self.assertContains(response, '{} Grant Recipient'.format(
-            grant.grant_type.grant_type))
-        self.assertContains(response, '{}–{}'.format(
-            grant.start_date.year, grant.end_date.year))
+        self.assertContains(response, '{} {} Grant Recipient'.format(
+            grant.end_date.year,
+            grant.grant_type.grant_type), html=True
+        )
 
         # non current grant - should shift to past list
         grant.end_date = date(2018, 1, 1)

--- a/cdhweb/people/tests.py
+++ b/cdhweb/people/tests.py
@@ -530,10 +530,10 @@ class TestViews(TestCase):
 
         # should display name and date from latest grant
         grant = fac.latest_grant
-        self.assertContains(response, '{} {} Grant Recipient'.format(
+        self.assertContains(response, '{}–{} {} Grant Recipient'.format(
+            grant.start_date.year,
             grant.end_date.year,
-            grant.grant_type.grant_type), html=True
-        )
+            grant.grant_type.grant_type), html=True)
 
         # non current grant - should shift to past list
         grant.end_date = date(2018, 1, 1)


### PR DESCRIPTION
Including grant year ranges created a mismatch between the years
listed and the name of the grant shown, which was only the
most recent one.

See #197