### PR TITLE
Person list refinements after first round of testing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,6 @@ CDH Website
     :alt: dbdocs build
 
 Python 3.6 / Django 2.2 / Node 10 / PostgreSQL 10
-
 `cdhweb` is a Django+Mezzanine application that powers the CDH website
 with custom models for people, events, and projects.
 
@@ -37,9 +36,9 @@ Development instructions
 
 Initial setup and installation:
 
-- Recommended: create and activate a python 3.5 virtualenv::
+- Recommended: create and activate a python 3.6 virtualenv::
 
-    virtualenv cdhweb -p python3.5
+    virtualenv cdhweb -p python3.6
     source cdhweb/bin/activate
 
 - Use pip to install required python dependencies.  To install production
@@ -77,6 +76,8 @@ Remember to add a ``SECRET_KEY`` setting!
 
   See `MariaDB <https://mariadb.com/kb/en/library/mysql_tzinfo_to_sql/>`_'s
   info on the utility for more information.
+
+- Install OpenCV dependencies (if necessary) for [wagtail image feature detection](https://docs.wagtail.io/en/stable/advanced_topics/images/feature_detection.html)
 
 Unit Testing
 ------------

--- a/cdhweb/pages/context_processors.py
+++ b/cdhweb/pages/context_processors.py
@@ -6,6 +6,9 @@ def page_intro(request):
     for this page, add it to the context for display.'''
     # wagtail stores link url without leading and trailing slashes,
     # but requests to django view urls include them; strip them off to match
+
+    # NOTE: page intro modification time is NOT taken into account
+    # when generating Last-Modified headers and returning 304 Not Modified
     page_intro = PageIntro.objects.filter(
         page__link_url=request.path.strip('/')).first()
     if page_intro:

--- a/cdhweb/people/templates/people/snippets/person_card.html
+++ b/cdhweb/people/templates/people/snippets/person_card.html
@@ -23,9 +23,7 @@
         <div class="content">
             <p class="name">{% firstof profile.title person %}</p>
             {# use in order of availability: cdh position, project role, event speaker + institution, job title + institution #}
-            <div class="title">
-                {{ person.label }}  {# display whatever label is set in the view #}
-
+            <div class="title">{{ person.label }}  {# display whatever label is set in the view #}
                 {% if show_events %} {# optionally show associated events #}
                     <div>
                     {% if person.user.event_set.published.upcoming %}
@@ -37,7 +35,6 @@
                     {% endif %}
                     </div>
                 {% endif %}
-
             </div>
         </div>
     </{{ tag }}>

--- a/cdhweb/people/templates/people/snippets/person_card.html
+++ b/cdhweb/people/templates/people/snippets/person_card.html
@@ -15,7 +15,7 @@
     {% with profile_url|yesno:"a,div" as tag %}
     <{{ tag }} {% if profile_url %}href="{{ profile_url }}"{% endif %} aria-label="{% firstof profile.title person %}">
         {% if person.image %}
-            {% image person.image max-310x240 as profile_img %}
+            {% image person.image fill-310x240-c15 as profile_img %}
             <div class="image" style="background-image:url('{{ profile_img.url }}')"></div>
         {% else %}
             <div class="image"></div>

--- a/cdhweb/people/tests/conftest.py
+++ b/cdhweb/people/tests/conftest.py
@@ -57,6 +57,10 @@ def grad_pi():
     Membership.objects.create(
         project=project, person=person, role=project_director,
         start_date=date(2015, 9, 1))
+    dataset_curation = GrantType.objects.get_or_create(grant_type='Dataset Curation')[0]
+    Grant.objects.create(grant_type=dataset_curation, project=project,
+                         start_date=date(2015, 9, 1),
+                         end_date=date.today() + timedelta(days=30))
     return person
 
 

--- a/cdhweb/people/tests/conftest.py
+++ b/cdhweb/people/tests/conftest.py
@@ -65,6 +65,22 @@ def grad_pi():
 
 
 @pytest.fixture
+def grad_pm():
+    person = Person.objects.create(
+        first_name='Tom', cdh_staff=False, pu_status='graduate')
+    project = Project.objects.create(title='Reconstructing the Past')
+    project_manager = Role.objects.get_or_create(title='Project Manager')[0]
+    Membership.objects.create(
+        project=project, person=person, role=project_manager,
+        start_date=date(2015, 9, 1))
+    dataset_curation = GrantType.objects.get_or_create(grant_type='Dataset Curation')[0]
+    Grant.objects.create(grant_type=dataset_curation, project=project,
+                         start_date=date(2015, 9, 1),
+                         end_date=date.today() + timedelta(days=30))
+    return person
+
+
+@pytest.fixture
 def faculty_pi():
     person = Person.objects.create(
         first_name='Josh', cdh_staff=False, pu_status='fac')

--- a/cdhweb/people/tests/test_views.py
+++ b/cdhweb/people/tests/test_views.py
@@ -7,7 +7,7 @@ from pytest_django.asserts import assertContains, assertNotContains
 
 from cdhweb.people.models import Person
 from cdhweb.people.views import AffiliateListView, ExecListView, \
-    SpeakerListView, StaffListView, StudentListView
+    StaffListView, StudentListView
 
 # NOTE: person factory fixtures in conftest
 
@@ -219,18 +219,5 @@ class TestExecListView:
 
 
 @pytest.mark.django_db
-class TestSpeakersListView:
-    url = reverse('people:speakers')
-
-    @pytest.mark.skip('todo')  # needs fixture, but wait on event exodus
-    def test_list_current(self, client, speaker):
-        '''test upcoming speakers'''
-        response = client.get(self.url)
-        assert speaker in response.context['current']
-
-    def test_display_label(self):
-        '''test display label for speaker'''
-        speaker = Person.objects.create(first_name='Jill', institution='IAS')
-        assert SpeakerListView().display_label(speaker) == \
-            speaker.institution
-
+def test_speakers_list_gone(client):
+    assert client.get('/people/speakers/').status_code == 410

--- a/cdhweb/people/tests/test_views.py
+++ b/cdhweb/people/tests/test_views.py
@@ -221,14 +221,21 @@ class TestExecListView:
 
     def test_display_label(self):
         '''test display label for exec'''
-        exec_member = Person.objects.create(first_name='Laura', job_title='Professor of Humanities')
+        exec_member = Person.objects.create(
+            first_name='Laura', job_title='Professor of Humanities')
         assert ExecListView().display_label(exec_member) == \
             exec_member.job_title
 
 
 @pytest.mark.django_db
 def test_speakers_list_gone(client):
-    assert client.get('/people/speakers/').status_code == 410
+    response = client.get('/people/speakers/')
+    assert response.status_code == 410
+    assertContains(response, '410', status_code=410)
+    assertContains(response, "That page isn&#39;t here anymore.",
+                   status_code=410)
+    assertNotContains(response, '404', status_code=410)
+    assertNotContains(response, "can't seem to find", status_code=410)
 
 
 @pytest.mark.django_db

--- a/cdhweb/people/urls.py
+++ b/cdhweb/people/urls.py
@@ -10,10 +10,13 @@ urlpatterns = [
     url(r'^staff/$', views.StaffListView.as_view(), name='staff'),
     url(r'^students/$', views.StudentListView.as_view(), name='students'),
     url(r'^affiliates/$', views.AffiliateListView.as_view(), name='affiliates'),
-    url(r'^speakers/$', views.SpeakerListView.as_view(), name='speakers'),
     url(r'^executive-committee/$', views.ExecListView.as_view(), name='exec-committee'),
     # redirect from /people/faculty -> /people/affiliates
     url(r'^faculty/$', RedirectView.as_view(url='/people/affiliates/', permanent=True)),
     # redirect from /people/postdocs -> /people/staff
     url(r'^postdocs/$', RedirectView.as_view(url='/people/staff/', permanent=True)),
+    # return 410 gone for speakers list view; unnamed to prevent links
+    # (removed in 3.0, no longer needed post Year of Data)
+    url(r'^speakers/$', RedirectView.as_view(url=None)),
+
 ]

--- a/cdhweb/people/urls.py
+++ b/cdhweb/people/urls.py
@@ -15,8 +15,5 @@ urlpatterns = [
     url(r'^faculty/$', RedirectView.as_view(url='/people/affiliates/', permanent=True)),
     # redirect from /people/postdocs -> /people/staff
     url(r'^postdocs/$', RedirectView.as_view(url='/people/staff/', permanent=True)),
-    # return 410 gone for speakers list view; unnamed to prevent links
-    # (removed in 3.0, no longer needed post Year of Data)
-    url(r'^speakers/$', RedirectView.as_view(url=None)),
-
+    url(r'^speakers/$', views.speakerlist_gone),
 ]

--- a/cdhweb/people/views.py
+++ b/cdhweb/people/views.py
@@ -234,13 +234,3 @@ class ExecListView(PersonListView):
             'sits_with': self.add_display_label(current.sits_with_exec()),
         })
         return context
-
-
-class SpeakerListGoneView(RedirectView):
-    '''Previously, this page displayed upcoming and past speakers;
-    removed in 3.0 since it's not longer relevant after Year of Data.
-    Use redirect view with no redirect url to return a 410 Gone.'''
-
-    def get_redirect_url(self, *args, **kwargs):
-        # explicitly return None to ensure we serve a 410 response
-        return None

--- a/cdhweb/people/views.py
+++ b/cdhweb/people/views.py
@@ -1,6 +1,6 @@
 from django.db.models import Case, Max, Value, When
 from django.db.models.functions import Greatest
-from django.views.generic.base import RedirectView
+from django.shortcuts import render
 from django.views.generic.list import ListView
 from django.urls import reverse
 
@@ -234,3 +234,12 @@ class ExecListView(PersonListView):
             'sits_with': self.add_display_label(current.sits_with_exec()),
         })
         return context
+
+
+def speakerlist_gone(request):
+    # return 410 gone for speakers list view;
+    # (removed in 3.0, no longer needed after the Year of Data)
+    return render(request, 'errors/404.html', context={
+        'error_code': 410,
+        'message': "That page isn't here anymore."
+    }, status=410)

--- a/cdhweb/people/views.py
+++ b/cdhweb/people/views.py
@@ -39,7 +39,7 @@ class PersonListView(ListView, LastModifiedListMixin):
 
     def display_label(self, person):
         # no default; force subclasses to implement
-        raise NotImplemented
+        raise NotImplementedError
 
     def add_display_label(self, queryset):
         # annotate the queryset with label to be displayed for this view

--- a/cdhweb/settings.py
+++ b/cdhweb/settings.py
@@ -125,6 +125,10 @@ TAGGIT_CASE_INSENSITIVE = True
 # https://docs.wagtail.io/en/latest/reference/settings.html#usage-for-images-documents-and-snippets
 WAGTAIL_USAGE_COUNT_ENABLED = True
 
+# enable feature detection in images
+WAGTAILIMAGES_FEATURE_DETECTION_ENABLED = True
+
+
 ########################
 # MAIN DJANGO SETTINGS #
 ########################

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -19,3 +19,4 @@ attrdict
 django-fullurl
 django-apptemplates
 wagtailmenus
+opencv-python

--- a/sitemedia/scss/site.scss
+++ b/sitemedia/scss/site.scss
@@ -745,6 +745,7 @@ $event-card-img-height: 240px;
                 font-style: italic;
                 font-family: $font-stack-body-text;
                 font-weight: normal;
+                white-space: pre-line;
 			}
 			.name {
 				margin: 0;
@@ -1277,7 +1278,7 @@ $event-card-img-height: 240px;
 			margin-top: 0;
 		}
     }
-    
+
     .grant-history {
         margin-top: 2rem;
 

--- a/templates/errors/404.html
+++ b/templates/errors/404.html
@@ -1,5 +1,6 @@
 {% extends 'errors/base.html' %}
+{# defaults to 404, but pass error code and message for alternate use #}
 {% load static %}
 
-{% block error-code %}404{% endblock %}
-{% block message %}We can’t seem to find the page you’re looking for.{% endblock %}
+{% block error-code %}{{ error_code|default:'404' }}{% endblock %}
+{% block message %}{{ message|default:"We can’t seem to find the page you’re looking for." }}{% endblock %}


### PR DESCRIPTION
This branch includes the following fixes related to person lists after first round acceptance testing:
- fix project director label for student affiliates
-  display multiple roles for student affiliates
-  check student page thumbnail display and adjust image resizing logic
- investigate including page intro modification time in last modified /conditional get (determined not to worry about it)
- remove speaker page

I checked the faculty/affiliate link page url and blurb text, this was a data problem in production and I corrected it. (I think the mezzanine page never got moved when the view was moved).

I investigated the student page thumbnail display and decided to enable image focal point detection. It looks like once this is turned on and the libraries are present, wagtail will automatically calculate focal point when images are created — which means its taken care of for us when we generate the images in our exodus script. I added the ubuntu package to our deploy but we will need to test in qa; it's possible we'll have some troubleshooting to do.

I struggled to find a good image crop/focus configuration that worked well for all the images we currently have. There are a couple of images that still look a little strange, might be worth tweaking it a little. In some cases we'll probably want to adjust the focal point manually to get the images to crop a little tighter.