### PR TITLE
More person list revisions

### DIFF
--- a/cdhweb/people/models.py
+++ b/cdhweb/people/models.py
@@ -313,11 +313,16 @@ class Person(ClusterableModel):
 
     @property
     def profile_url(self):
-        """Use an internal profile if available, otherwise try website url"""
-        if self.profile:
+        """Provide the link to profile on this site if there is one;
+        otherwise look for an associated website url"""
+        try:
             return self.profile.get_url()
-        elif self.related_links.filter(type__name="Website").exists():
-            return self.related_links.filter(type__name="Website").first().url
+            # NOTE: should we check profile published/draft status here?
+        except Profile.DoesNotExist:
+
+            website = self.related_links.filter(type__name="Website").first()
+            if website:
+                return website.url
 
     @receiver(pre_delete, sender="people.Person")
     def cleanup_profile(sender, **kwargs):

--- a/cdhweb/people/templates/people/profile.html
+++ b/cdhweb/people/templates/people/profile.html
@@ -20,7 +20,7 @@
 <div class="links">
     {# NOTE equiv to contributors in project #}
     <ul>
-    {% for link in person.related_links.all %}
+    {% for link in page.person.related_links.all %}
         <li><a href="{{ link.url }}">{{ link.type.name }}</a></li>
     {% endfor %}
     </ul>

--- a/cdhweb/people/tests/test_models.py
+++ b/cdhweb/people/tests/test_models.py
@@ -90,6 +90,15 @@ class TestPerson(TestCase):
         assert str(self.person) == "tom jones"
 
 
+def test_profile_url(student, staffer_profile, faculty_pi):
+    # student fixture has neither profile nor website link
+    assert not student.profile_url
+    # staff person has local profile
+    assert staffer_profile.person.profile_url == staffer_profile.get_url()
+    # faculty pi has a profile url
+    assert faculty_pi.profile_url == 'example.com'
+
+
 class TestPersonQuerySet(TestCase):
 
     def setUp(self):

--- a/cdhweb/people/views.py
+++ b/cdhweb/people/views.py
@@ -188,7 +188,7 @@ class AffiliateListView(PersonListView):
     def get_queryset(self):
         # filter to affiliates, annotate with grant years, and order by name
         return super().get_queryset().affiliates().grant_years() \
-                      .order_by('user__last_name')
+                      .order_by('last_name')
 
     def display_label(self, person):
         # use grant information as label


### PR DESCRIPTION
Adjustments based on person list testing feedback — ref #267 

- `profile_url` logic didn't handle the case where there was no profile; no unit test, either so I added one
- related link display was due to bad variable in the template; I didn't see an obvious place to add a unit test for this (no template / display tests included in person page tests currently)
- affiliates was sorting on user last name, which doesn't exist anymore! corrected to use person last name