### PR TITLE
person email

### DIFF
--- a/cdhweb/people/migrations/0010_nonproxy_person.py
+++ b/cdhweb/people/migrations/0010_nonproxy_person.py
@@ -20,6 +20,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('first_name', models.CharField(max_length=150, verbose_name='first name')),
                 ('last_name', models.CharField(max_length=150, verbose_name='last name')),
+                ('email', models.EmailField(blank=True, max_length=254, null=True)),
                 ('cdh_staff', models.BooleanField('CDH Staff', default=False, help_text='CDH staff or Postdoctoral Fellow.')),
                 ('job_title', models.CharField(blank=True, help_text='Professional title, e.g. Professor or Assistant Professor', max_length=255)),
                 ('department', models.CharField(blank=True, help_text='Academic Department at Princeton or other institution (optional)', max_length=255)),

--- a/cdhweb/people/migrations/0011_populate_nonproxy_person.py
+++ b/cdhweb/people/migrations/0011_populate_nonproxy_person.py
@@ -20,7 +20,8 @@ def create_nonproxy_persons(apps, schema_editor):
         person_info = {
             'user': user,
             'first_name': user.first_name,
-            'last_name': user.last_name
+            'last_name': user.last_name,
+            'email': user.email,
         }
         # get profile if there is one (not all users have them)
         profile = getattr(user, 'profile', None)

--- a/cdhweb/people/templates/people/profile.html
+++ b/cdhweb/people/templates/people/profile.html
@@ -1,14 +1,14 @@
 {% extends 'base.html' %}
 {% load wagtailcore_tags wagtailimages_tags %}
 
-{% block page-subtitle %}{{ page.title }} | People | {% endblock %}
+{% block page-subtitle %}{{ profile.title }} | People | {% endblock %}
 
 {% block main %}
 <div class="profile">
 <header>
-    <h1>{{ page.title }}</h1>
+    <h1>{{ profile.title }}</h1>
     {# display all positions, current first; dates for non-current #}
-    {% for position in page.person.positions.all %}
+    {% for position in profile.person.positions.all %}
         <p class="title">{% if not position.is_current %}
             {{ position.start_date.year }}{% if position.end_date.year != position.start_date.year%}-{{ position.end_date.year }}{% endif %}
             {% endif %}
@@ -20,30 +20,30 @@
 <div class="links">
     {# NOTE equiv to contributors in project #}
     <ul>
-    {% for link in page.person.related_links.all %}
+    {% for link in profile.person.related_links.all %}
         <li><a href="{{ link.url }}">{{ link.type.name }}</a></li>
     {% endfor %}
     </ul>
 </div>
 
-{% if page.image %}
-    {% image page.image fill-790x632 as profile_img %}
-    <img src="{{ profile_img.url }}" alt="{{ page.title }}"/>
+{% if profile.image %}
+    {% image profile.image fill-790x632 as profile_img %}
+    <img src="{{ profile_img.url }}" alt="{{ profile.title }}"/>
 {% endif %}
 
 <div class="education">
-    {{ page.education|richtext }}
-    <a href="mailto:{{ page.person.user.email }}">{{ page.person.user.email }}</a>
-    {% if page.person.phone_number %}
-        <p>{{ page.person.phone_number }}</p>
+    {{ profile.education|richtext }}
+    <a href="mailto:{{ profile.person.email }}">{{ profile.person.email }}</a>
+    {% if profile.person.phone_number %}
+        <p>{{ profile.person.phone_number }}</p>
     {% endif %}
-    {% if page.person.office_location %}
-        <p>{{ page.person.office_location }}</p>
+    {% if profile.person.office_location %}
+        <p>{{ profile.person.office_location }}</p>
     {% endif %}
 </div>
 
 <div class="bio">
-    {% for block in page.bio %}
+    {% for block in profile.bio %}
         {% include_block block %}
     {% endfor %}
 </div>

--- a/cdhweb/people/tests/test_models.py
+++ b/cdhweb/people/tests/test_models.py
@@ -402,8 +402,9 @@ class TestInitProfileFromLDAP(TestCase):
         self.staff_person = Person.objects.get(user=self.staff_user)
 
     def test_email(self):
-        """user email should be converted to lower case"""
+        """user email should be converted to lower case and added to person"""
         assert self.staff_user.email == "staff@example.com"
+        assert self.staff_person.email == "staff@example.com"
 
     def test_person_created(self):
         """person should be created to match user"""

--- a/cdhweb/people/tests/test_templates.py
+++ b/cdhweb/people/tests/test_templates.py
@@ -30,7 +30,13 @@ class TestProfile(TestCase):
         # set up user/person/profile
         User = get_user_model()
         self.user = User.objects.create_user(username="tom")
-        self.person = Person.objects.create(user=self.user, first_name="tom")
+        self.person = Person.objects.create(
+            user=self.user,
+            first_name="tom",
+            email="tom@princeton.edu",
+            phone_number="609-000-0000",
+            office_location="on campus",
+        )
         self.profile = Profile(
             person=self.person,
             title="tom r. jones",
@@ -55,6 +61,22 @@ class TestProfile(TestCase):
         """profile page should display person's bio"""
         response = self.client.get(self.profile.relative_url(self.site))
         self.assertContains(response, "<b>about me</b>", html=True)
+
+    def test_email(self):
+        """profile page should display person's email"""
+        response = self.client.get(self.profile.relative_url(self.site))
+        self.assertContains(
+            response, '<a href="mailto:tom@princeton.edu">tom@princeton.edu</a>', html=True)
+
+    def test_phone_number(self):
+        """profile page should display person's phone number"""
+        response = self.client.get(self.profile.relative_url(self.site))
+        self.assertContains(response, "<p>609-000-0000</p>", html=True)
+
+    def test_office_location(self):
+        """profile page should display person's office location"""
+        response = self.client.get(self.profile.relative_url(self.site))
+        self.assertContains(response, "<p>on campus</p>", html=True)
 
     def test_positions(self):
         """profile page should display all positions held by its person"""

--- a/cdhweb/people/wagtail_hooks.py
+++ b/cdhweb/people/wagtail_hooks.py
@@ -12,7 +12,7 @@ class PersonAdmin(ThumbnailMixin, ModelAdmin):
     list_display_add_buttons = "first_name"
     search_fields = ("first_name", "last_name", "user__username")
     list_filter = ("pu_status", "cdh_staff")
-    list_export = ("first_name", "last_name", "most_recent_title", "department",
+    list_export = ("first_name", "last_name", "email", "most_recent_title", "department",
                    "cdh_staff", "pu_status", "latest_grant", "profile_url")
     list_per_page = 25
     export_filename = "cdhweb-people"


### PR DESCRIPTION
small PR based off of #289; will rebase against develop when that is merged.

fixes an issue identified by @manawinters on #181 – some people no longer have emails displayed on their `Profile` in v3 because that information was stored on `User` and would otherwise be lost (most extraneous `User`s will become `Person`s in v3).

this PR resolves it by:
- adding an `Email` field to `Person`
- populating the field if it's empty when `init_person_from_ldap` is run
- populating the field based on `User.email` in an existing migration so that information from `User` isn't lost

it also uses a better context object name in the `Profile` template and improves template tests.