### PR TITLE
feature/sitemaps

### DIFF
--- a/cdhweb/blog/models.py
+++ b/cdhweb/blog/models.py
@@ -204,6 +204,15 @@ class BlogPost(BasePage, ClusterableModel, PagePreviewDescriptionMixin):
             })
             return site_id, root_url, page_path
 
+    def get_sitemap_urls(self, request):
+        """Override sitemap listings to add priority for featured posts."""
+        # output is a list of dict; there should only ever be one element. see:
+        # https://docs.wagtail.io/en/stable/reference/contrib/sitemaps.html#urls
+        urls = super().get_sitemap_urls(request=request)
+        if self.featured:
+            urls[0]["priority"] = 0.6   # default is 0.5; slight increase
+        return urls
+
 
 class BlogLinkPage(LinkPage):
     """Container page that defines where blog posts can be created."""

--- a/cdhweb/blog/tests/test_pages.py
+++ b/cdhweb/blog/tests/test_pages.py
@@ -46,6 +46,18 @@ class TestBlogPost:
         # should pad with zeroes and include year, month, day, slug
         assert article.get_url() == "/updates/2019/03/04/%s/" % article.slug
 
+    def test_sitemap(self, rf, article):
+        """blog post should have increased priority in sitemap if featured"""
+        # post that's not featured doesn't set priority (default is 0.5)
+        request = rf.get(article.get_url())
+        sitemap_urls = article.get_sitemap_urls(request=request)
+        assert "priority" not in sitemap_urls[0]
+        # featured post gets slightly increased priority (0.6)
+        article.featured = True
+        article.save()
+        request = rf.get(article.get_url())
+        sitemap_urls = article.get_sitemap_urls(request=request)
+        assert sitemap_urls[0]["priority"] == 0.6
 
 class TestBlogPostPage(WagtailPageTests):
 

--- a/cdhweb/pages/management/commands/exodus.py
+++ b/cdhweb/pages/management/commands/exodus.py
@@ -105,6 +105,10 @@ class Command(BaseCommand):
         site.save()
         Page.objects.filter(depth=2).exclude(pk=homepage.pk).delete()
 
+        # set the site's hostname so that sitemaps will be valid
+        site.hostname = "cdh.princeton.edu"
+        site.save()
+
         # create a LinkPage to serve as the projects/ root (project list page)
         try:
             old_projects = MezzaninePage.objects.get(slug="projects")

--- a/cdhweb/projects/models.py
+++ b/cdhweb/projects/models.py
@@ -290,6 +290,17 @@ class Project(BasePage, ClusterableModel):
             .exclude(membership__in=self.current_memberships()) \
             .order_by("last_name")
 
+    def get_sitemap_urls(self, request):
+        """Override sitemap to prioritize projects built by CDH with a website."""
+        # output is a list of dict; there should only ever be one element. see:
+        # https://docs.wagtail.io/en/stable/reference/contrib/sitemaps.html#urls
+        urls = super().get_sitemap_urls(request=request)
+        if self.website_url and self.cdh_built:
+            urls[0]["priority"] = 0.7
+        elif self.website_url or self.cdh_built:
+            urls[0]["priority"] = 0.6
+        return urls
+
 
 class GrantType(models.Model):
     '''Model to track kinds of grants'''

--- a/cdhweb/urls.py
+++ b/cdhweb/urls.py
@@ -6,6 +6,7 @@ from django.contrib import admin
 from django.urls import include, path, re_path
 from django.views.generic.base import RedirectView, TemplateView
 from wagtail.admin import urls as wagtailadmin_urls
+from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
@@ -41,6 +42,9 @@ urlpatterns = [
     # - all blog urls are now under updates/
     re_path(r'^blog(?P<blog_url>.*)$',
             RedirectView.as_view(url='/updates%(blog_url)s', permanent=True)),
+
+    # sitemaps
+    path("sitemap.xml", sitemap),
 
     # wagtail paths
     # NOTE temporarily make wagtail pages available at pages/ so that they can


### PR DESCRIPTION
- Add wagtail default sitemap
- Add sitemap priority function for blog posts
- Add sitemap priority function for projects
- Set wagtail Site's hostname to cdh.princeton.edu in exodus

I implemented the sitemap priority calculation for projects and blog posts to match how they're calculated in current production; they became methods on wagtail `Page`. As far as I can tell, this is all we need to do! It looks like everything's present in the sitemap and automatically uses the right modification dates, etc.
