### PR TITLE
feature/exodus history (#247)

### DIFF
--- a/cdhweb/blog/exodus.py
+++ b/cdhweb/blog/exodus.py
@@ -4,7 +4,7 @@ import logging
 from mezzanine.core.models import CONTENT_STATUS_PUBLISHED
 
 from cdhweb.blog.models import Author, BlogLinkPage, BlogPost, OldBlogPost
-from cdhweb.pages.exodus import (convert_slug, exodize_attachments,
+from cdhweb.pages.exodus import (convert_slug, exodize_attachments, exodize_history,
                                  get_wagtail_image, to_streamfield)
 from cdhweb.people.models import Person
 
@@ -38,16 +38,16 @@ def blog_exodus():
 
         # add it as a child of blog landing page so slugs are correct
         blog_link.add_child(instance=post_page)
-        blog_link.save()
+        blog_link.save(log_action=False)
 
         # if the old post wasn't published, unpublish the new one
         if post.status != CONTENT_STATUS_PUBLISHED:
-            post_page.unpublish()
+            post_page.unpublish(log_action=False)
 
         # set publication dates
         post_page.first_published_at = post.publish_date
         post_page.last_published_at = post.updated
-        post_page.save()
+        post_page.save(log_action=False)
 
         # transfer authors
         for user in post.users.all():
@@ -56,5 +56,6 @@ def blog_exodus():
 
         # transfer attachments
         exodize_attachments(post, post_page)
+        exodize_history(post, post_page)
 
         # NOTE no tags to migrate

--- a/cdhweb/events/exodus.py
+++ b/cdhweb/events/exodus.py
@@ -4,7 +4,7 @@ import logging
 from mezzanine.core.models import CONTENT_STATUS_PUBLISHED
 
 from cdhweb.events.models import Event, EventsLinkPage, OldEvent, Speaker
-from cdhweb.pages.exodus import (convert_slug, exodize_attachments,
+from cdhweb.pages.exodus import (convert_slug, exodize_attachments, exodize_history,
                                  get_wagtail_image, to_streamfield)
 from cdhweb.people.models import Person
 
@@ -40,16 +40,16 @@ def event_exodus():
 
         # add it as child of event landing page so slugs are correct
         event_link.add_child(instance=event_page)
-        event_link.save()
+        event_link.save(log_action=False)
 
         # if the old event wasn't published, unpublish the new one
         if event.status != CONTENT_STATUS_PUBLISHED:
-            event_page.unpublish()
+            event_page.unpublish(log_action=False)
 
         # set publication dates
         event_page.first_published_at = event.publish_date
         event_page.last_published_at = event.updated
-        event_page.save()
+        event_page.save(log_action=False)
 
         # add speakers
         for user in event.speakers.all():
@@ -58,5 +58,6 @@ def event_exodus():
 
         # transfer attachments
         exodize_attachments(event, event_page)
+        exodize_history(event, event_page)
         
         # NOTE no tags to migrate

--- a/cdhweb/pages/management/commands/exodus.py
+++ b/cdhweb/pages/management/commands/exodus.py
@@ -113,9 +113,7 @@ class Command(BaseCommand):
 
         # also delete any log entries referencing pages from previous runs, 
         # otherwise they'll stick around and point to nothing since PKs change.
-        # objects.delete() isn't implemented so we do it via iterating
-        for entry in PageLogEntry.objects.all():
-            entry.delete()
+        PageLogEntry.objects.all().delete()
 
         # set the site's hostname so that sitemaps will be valid
         site.hostname = "cdh.princeton.edu"

--- a/cdhweb/pages/management/commands/exodus.py
+++ b/cdhweb/pages/management/commands/exodus.py
@@ -8,7 +8,6 @@ import os.path
 import shutil
 import warnings
 from collections import defaultdict
-from operator import attrgetter
 from itertools import chain
 
 from django.conf import settings
@@ -17,9 +16,11 @@ from django.core.management.base import BaseCommand, CommandParser
 from django.db.models import Q
 from django.test import override_settings
 from mezzanine.core.models import CONTENT_STATUS_PUBLISHED
-from mezzanine.pages.models import Page as MezzaninePage, Link as MezzanineLink
-from wagtail.core.models import Collection, Page, Site, get_root_collection_id
+from mezzanine.pages.models import Link as MezzanineLink
+from mezzanine.pages.models import Page as MezzaninePage
 from wagtail.contrib.redirects.models import Redirect
+from wagtail.core.models import (Collection, Page, PageLogEntry, Site,
+                                 get_root_collection_id)
 from wagtail.images.models import Image
 
 from cdhweb.blog.exodus import blog_exodus
@@ -28,10 +29,10 @@ from cdhweb.events.exodus import event_exodus
 from cdhweb.events.models import EventsLinkPage
 from cdhweb.pages.exodus import (convert_slug, create_contentpage,
                                  create_homepage, create_landingpage,
-                                 create_link_page, exodize_attachments, form_pages,
+                                 create_link_page, exodize_attachments,
+                                 exodize_history, form_pages,
                                  get_wagtail_image)
-from cdhweb.pages.models import ExternalAttachment, HomePage, LocalAttachment,\
-    LinkPage
+from cdhweb.pages.models import HomePage, LinkPage
 from cdhweb.people.exodus import people_exodus, user_group_exodus
 from cdhweb.people.models import PeopleLandingPage
 from cdhweb.projects.exodus import project_exodus
@@ -97,15 +98,24 @@ class Command(BaseCommand):
             )
         root = Page.objects.get(depth=1)
         root.add_child(instance=homepage)
-        root.save()
+        root.save(log_action=False)
+        exodize_history(old_homepage, homepage)
 
         # point the default site at the new homepage and delete any others.
         # if they are deleted prior to switching site.root_page, the site will
-        # also be deleted in a cascade, which we don't want
+        # also be deleted in a cascade, which we don't want.
         site = Site.objects.get()
         site.root_page = homepage
         site.save()
-        Page.objects.filter(depth=2).exclude(pk=homepage.pk).delete()
+        Page.objects.filter(depth=2) \
+                    .exclude(pk=homepage.pk) \
+                    .delete()
+
+        # also delete any log entries referencing pages from previous runs, 
+        # otherwise they'll stick around and point to nothing since PKs change.
+        # objects.delete() isn't implemented so we do it via iterating
+        for entry in PageLogEntry.objects.all():
+            entry.delete()
 
         # set the site's hostname so that sitemaps will be valid
         site.hostname = "cdh.princeton.edu"
@@ -121,7 +131,8 @@ class Command(BaseCommand):
                 show_in_menus=True,
             )
             homepage.add_child(instance=events)
-            homepage.save()
+            homepage.save(log_action=False)
+            exodize_history(old_events, events)
             self.migrated.append(old_events.pk)
         except MezzaninePage.DoesNotExist:
             logging.warning("no events/ page tree found; skipping events")
@@ -137,7 +148,8 @@ class Command(BaseCommand):
                 show_in_menus=True
             )
             homepage.add_child(instance=updates)
-            homepage.save()
+            homepage.save(log_action=False)
+            exodize_history(old_updates, updates)
             self.migrated.append(old_updates.pk)
         except MezzaninePage.DoesNotExist:
             logging.warning("no updates/ page tree found; skipping blog")
@@ -160,8 +172,8 @@ class Command(BaseCommand):
                 show_in_menus=True
             )
             homepage.add_child(instance=people)
-            homepage.save()
-            # mark as migrated
+            homepage.save(log_action=False)
+            exodize_history(old_people, people)
             self.migrated.append(old_people.pk)
         except MezzaninePage.DoesNotExist:
             logging.warning("no people/ page tree found; skipping people")
@@ -199,7 +211,8 @@ class Command(BaseCommand):
             # revise the slug and add as a child of the home page
             projects.slug = "projects"
             homepage.add_child(instance=projects)
-            homepage.save()
+            homepage.save(log_action=False)
+            exodize_history(old_projects_landing, projects)
             self.migrated.append(old_projects_landing.pk)
             # create redirect from old landing page to new page
             Redirect.add_redirect(
@@ -222,7 +235,8 @@ class Command(BaseCommand):
                 )
                 # add as child of new projects landing page
                 projects.add_child(instance=sponsored_projects)
-                projects.save()
+                projects.save(log_action=False)
+                exodize_history(old_projects, sponsored_projects)
                 self.migrated.append(old_projects.pk)
                 # note that we can't add a redirect for this change,
                 # since the old url needs to resolve to the new landing page
@@ -234,7 +248,8 @@ class Command(BaseCommand):
                 .filter(Q(slug__startswith="projects")).order_by('-slug')
             for page in project_pages:
                 if page.pk not in self.migrated:
-                    create_link_page(page, projects)
+                    new_page = create_link_page(page, projects)
+                    exodize_history(page, new_page)
                     self.migrated.append(page.pk)
 
         # migrate blog pages
@@ -284,15 +299,15 @@ class Command(BaseCommand):
         # report on unmigrated attachments
         attachment_pages = set(chain.from_iterable(
             [a.pages.all() for a in Attachment.objects.all()]))
-        new_attachment_pages = list(filter(lambda p: getattr(
-            p, "attachments", None) is not None, Page.objects.all()))
+        new_attachment_pages = list(filter(lambda p: hasattr(p, "attachments"),
+                                           Page.objects.all()))
         n_old_pages = len(attachment_pages)
         n_new_pages = len(new_attachment_pages)
-        logging.info("%d mezzanine and %d wagtail pages with attachments",
-                     (n_old_pages, n_new_pages))
-        if n_old_pages != n_new_pages:
-            logging.warning("%d pages with umigrated attachments",
-                            n_old_pages - n_new_pages)
+        if n_old_pages > n_new_pages:
+            missing_pages = set([p.title for p in attachment_pages]) - \
+                set([p.title for p in new_attachment_pages])
+            logging.warning("%d pages with umigrated attachments: %s" % (
+                            n_old_pages - n_new_pages, ", ".join(missing_pages)))
 
         # delete mezzanine pages here? (but keep for testing migration)
 
@@ -333,16 +348,17 @@ class Command(BaseCommand):
                     "converting link page to content page %s " % page)
                 # TODO: adapt new create_link_page method for these links
             new_page = create_contentpage(page)
-            # move any attachments
 
         parent.add_child(instance=new_page)
-        parent.save()
+        parent.save(log_action=False)
 
+        # move any attachments & log entries
         exodize_attachments(page, new_page)
+        exodize_history(page, new_page)
 
         # set publication status
         if page.status != CONTENT_STATUS_PUBLISHED:
-            new_page.unpublish()
+            new_page.unpublish(log_action=False)
 
         # add to list of migrated pages
         self.migrated.append(page.pk)

--- a/cdhweb/pages/wagtail_hooks.py
+++ b/cdhweb/pages/wagtail_hooks.py
@@ -3,6 +3,7 @@ from django.templatetags.static import static
 
 from wagtail.core import hooks
 
+
 @hooks.register("insert_global_admin_css")
 def global_admin_css():
     """Add wagtail custom admin CSS."""
@@ -10,3 +11,10 @@ def global_admin_css():
         '<link rel="stylesheet" href="{}">',
         static("wagtailadmin/css/custom.css")
     )
+
+
+@hooks.register("register_log_actions")
+def register_exodus_log_action(actions):
+    """Add a custom PageLogEntry action to mark page exodus from Mezzanine."""
+    actions.register_action("cdhweb.exodus", "Exodus",
+                            "Migrated from cdhweb v2")

--- a/cdhweb/projects/exodus.py
+++ b/cdhweb/projects/exodus.py
@@ -3,8 +3,9 @@ import logging
 
 from mezzanine.core.models import CONTENT_STATUS_PUBLISHED
 
-from cdhweb.pages.exodus import convert_slug, exodize_attachments, \
-    get_wagtail_image, to_streamfield
+from cdhweb.pages.exodus import (convert_slug, exodize_attachments,
+                                 exodize_history, get_wagtail_image,
+                                 to_streamfield)
 from cdhweb.projects.models import OldProject, Project, ProjectsLandingPage
 
 
@@ -36,16 +37,16 @@ def project_exodus():
 
         # add it as child of project landing page so slugs are correct
         project_landing.add_child(instance=project_page)
-        project_landing.save()
+        project_landing.save(log_action=False)
 
         # if the old project wasn't published, unpublish the new one
         if project.status != CONTENT_STATUS_PUBLISHED:
-            project_page.unpublish()
+            project_page.unpublish(log_action=False)
 
         # set publication dates
         project_page.first_published_at = project.publish_date
         project_page.last_published_at = project.updated
-        project_page.save()
+        project_page.save(log_action=False)
 
         # transfer memberships
         for membership in project.membership_set.all():
@@ -67,5 +68,6 @@ def project_exodus():
 
         # transfer attachments
         exodize_attachments(project, project_page)
-
+        exodize_history(project, project_page)
+        
         # NOTE no tags to migrate


### PR DESCRIPTION
- Implement django log entry exodizing
- Add a custom log action type for exodus
- Exodize log entries in main exodus script
- Exodize log entries for blog, event, people, project pages
- Update user/group exodus

this uses the new strategy to migrate log entries to `PageLogEntry`. It also makes sure an initial page revision exists in wagtail, otherwise the "history" button doesn't show up until you make some kind of change. you can access the history for each page at the top next to the "last revision published at" display, or via the global log (that one is in "reports" on the left menu and is only visible to superusers). all of the `log_action=False` changes are to prevent populating the logs with changes that are made via the exodus; instead we add a single custom log entry per model to mark the exodus event.

for the user/group exodus, we now delete accounts with no login/edit history (the vast majority) and mark any remaining accounts with no current cdh position as inactive (this seemed to do the right thing when testing). also adds rsk and nb as superusers.
