### PR TITLE
feature/head meta

### DIFF
--- a/cdhweb/blog/exodus.py
+++ b/cdhweb/blog/exodus.py
@@ -2,10 +2,13 @@
 import logging
 
 from mezzanine.core.models import CONTENT_STATUS_PUBLISHED
+from taggit.models import Tag
 
-from cdhweb.blog.models import Author, BlogLinkPage, BlogPost, OldBlogPost
-from cdhweb.pages.exodus import (convert_slug, exodize_attachments, exodize_history,
-                                 get_wagtail_image, to_streamfield)
+from cdhweb.blog.models import (Author, BlogLinkPage, BlogPost, BlogPostTag,
+                                OldBlogPost)
+from cdhweb.pages.exodus import (convert_slug, exodize_attachments,
+                                 exodize_history, get_wagtail_image,
+                                 to_streamfield)
 from cdhweb.people.models import Person
 
 
@@ -58,4 +61,8 @@ def blog_exodus():
         exodize_attachments(post, post_page)
         exodize_history(post, post_page)
 
-        # NOTE no tags to migrate
+        # exodize keywords as tags
+        for kw in post.keywords.all():
+            logging.debug("exodizing blog tag %s" % kw.keyword.title)
+            tag = Tag.objects.get_or_create(name=kw.keyword.title)[0]
+            BlogPostTag.objects.create(content_object=post_page, tag=tag)

--- a/cdhweb/blog/models.py
+++ b/cdhweb/blog/models.py
@@ -167,8 +167,6 @@ class BlogPost(BasePage, ClusterableModel, PagePreviewDescriptionMixin):
     # custom manager/queryset logic
     objects = BlogPostManager()
 
-    context_object_name = "post"
-
     @property
     def short_title(self):
         """Shorter title with ellipsis."""

--- a/cdhweb/blog/templates/blog/base.html
+++ b/cdhweb/blog/templates/blog/base.html
@@ -1,13 +1,11 @@
 {% extends 'base.html' %}
 {# base template for blog pages with rss/atom header links for autodiscovery #}
 
-{% block page-subtitle %}Updates | {% endblock %}
-
 {% block extra-head %}
 <link rel="alternate" type="application/rss+xml" href="{% url 'blog:rss' %}"
-    title="Updates | Center for Digital Humanities @ Princeton University"/>
+    title="Updates – CDH@Princeton"/>
 <link rel="alternate" type="application/atom+xml" href="{% url 'blog:atom' %}"
-    title="Updates | Center for Digital Humanities @ Princeton University"/>
+    title="Updates – CDH@Princeton"/>
 {% endblock %}
 
 

--- a/cdhweb/blog/templates/blog/blogpost_archive.html
+++ b/cdhweb/blog/templates/blog/blogpost_archive.html
@@ -1,10 +1,9 @@
 {% extends 'blog/base.html' %}
 {% load humanize %}
 
-{% block page-subtitle %}{% firstof title 'Latest' %} {{ block.super }}{% endblock %}
+{% block page-title %}{{ title|default:'Latest' }} Updates{% endblock %}
 
 {% block main %}
-
 <section class="blogposts">
 
 <h1>{{ title|default:'Latest' }} Updates</h1>

--- a/cdhweb/blog/templates/blog/blogpost_archive_year.html
+++ b/cdhweb/blog/templates/blog/blogpost_archive_year.html
@@ -1,10 +1,6 @@
 {% extends 'blog/base.html' %}
 {% load humanize %}
 
-{% block page-subtitle %}{{ post.title }} | Updates | {% endblock %}
-
-
-
 {% block main %}
 <h3>Archives</h3>
 

--- a/cdhweb/blog/templates/blog/blogpost_detail.html
+++ b/cdhweb/blog/templates/blog/blogpost_detail.html
@@ -2,14 +2,14 @@
 {% load wagtailcore_tags humanize %}
 {# simple blog post page; adapted in part from mezzanine blog post template #}
 
-{% block page-subtitle %}{{ post.title }} | {{ block.super }}{% endblock %}
+{% block page-subtitle %}{{ page.title }} | {{ block.super }}{% endblock %}
 
 {% block headattrs %} xmlns:article="http://ogp.me/ns/article#"{% endblock %}
 {% block extra-head %}
-    <meta name="article.published_time" content="{{ post.first_published_at.isoformat }}"/>
-    <meta name="article.modified_time" content="{{ post.last_published_at.isoformat }}"/>
-    {% if post.authors.exists %}
-      {% for author in post.authors.all %}
+    <meta name="article.published_time" content="{{ page.first_published_at.isoformat }}"/>
+    <meta name="article.modified_time" content="{{ page.last_published_at.isoformat }}"/>
+    {% if page.authors.exists %}
+      {% for author in page.authors.all %}
         {% if author.person.profile_url %}
         {# facebook requires url; provide local or external if we have it #}
     <meta name="article.author" content="{{ author.person.profile_url }}"/>
@@ -25,16 +25,16 @@
 {% block main %}
 <article typeof="schema:BlogPosting" class="blogpost">
     <header>
-        <h1 property="schema:headline">{{ post.title }}</h1>
-        <meta property="schema:url schema:mainEntityOfPage" content="{% pageurl post %}"/>
+        <h1 property="schema:headline">{{ page.title }}</h1>
+        <meta property="schema:url schema:mainEntityOfPage" content="{% pageurl page %}"/>
         {# FIXME: do we need full url here? #}
-        <meta property="schema:datePublished" content="{{ post.first_published_at|date:"c" }}"/>
-        <meta property="schema:dateModified" content="{{ post.last_published_at|date:"c" }}"/>
+        <meta property="schema:datePublished" content="{{ page.first_published_at|date:"c" }}"/>
+        <meta property="schema:dateModified" content="{{ page.last_published_at|date:"c" }}"/>
 
         <div class="byline">
-        {% if post.authors.exists %}
+        {% if page.authors.exists %}
         <div class="authors">
-        {% for author in post.authors.all %}
+        {% for author in page.authors.all %}
             <span property="schema:author" typeof="schema:Person">
                 <a {% if author.person.profile_url %}property="schema:url" href="{{ author.person.profile_url }}"{% endif %}>
                 <span property="schema:name">{{ author.person }}</span></a>{% if not forloop.last %}, {% endif %}
@@ -42,7 +42,7 @@
         {% endfor %}
         </div><br/>
         {% endif %}
-        <span class="date-published">{{ post.first_published_at|date:"F j, Y" }}</span>
+        <span class="date-published">{{ page.first_published_at|date:"F j, Y" }}</span>
         {# NOTE: google structured data testing tool claims publisher and image are required #}
             <div property="schema:publisher" style="display:none">
               <span typeof="schema:Organization">
@@ -54,7 +54,7 @@
     </header>
 
     <div class="content" property="schema:articleBody">
-        {% include_block post.body %}
+        {% include_block page.body %}
     </div>
 
 

--- a/cdhweb/blog/templates/blog/blogpost_detail.html
+++ b/cdhweb/blog/templates/blog/blogpost_detail.html
@@ -2,8 +2,6 @@
 {% load wagtailcore_tags humanize %}
 {# simple blog post page; adapted in part from mezzanine blog post template #}
 
-{% block page-subtitle %}{{ page.title }} | {{ block.super }}{% endblock %}
-
 {% block headattrs %} xmlns:article="http://ogp.me/ns/article#"{% endblock %}
 {% block extra-head %}
     <meta name="article.published_time" content="{{ page.first_published_at.isoformat }}"/>

--- a/cdhweb/blog/templates/blog/blogpost_detail.html
+++ b/cdhweb/blog/templates/blog/blogpost_detail.html
@@ -24,7 +24,7 @@
 <article typeof="schema:BlogPosting" class="blogpost">
     <header>
         <h1 property="schema:headline">{{ page.title }}</h1>
-        <meta property="schema:url schema:mainEntityOfPage" content="{% pageurl page %}"/>
+        <meta property="schema:url schema:mainEntityOfPage" content="{{ page.get_full_url }}"/>
         {# FIXME: do we need full url here? #}
         <meta property="schema:datePublished" content="{{ page.first_published_at|date:"c" }}"/>
         <meta property="schema:dateModified" content="{{ page.last_published_at|date:"c" }}"/>

--- a/cdhweb/blog/tests/test_views.py
+++ b/cdhweb/blog/tests/test_views.py
@@ -52,7 +52,7 @@ class TestBlogPostDetailView:
     def test_context_obj(self, client, announcement):
         """blog post detail view should serve blog post in context"""
         response = client.get(announcement.get_url())
-        assert response.context["post"] == announcement
+        assert response.context["page"] == announcement
 
     def test_draft_404(self, client, announcement):
         """blog post detail view should serve 404 for draft posts"""

--- a/cdhweb/blog/views.py
+++ b/cdhweb/blog/views.py
@@ -66,7 +66,7 @@ class BlogMonthArchiveView(BlogPostArchiveMixin, MonthArchiveView):
 class BlogDetailView(BlogPostMixinView, DetailView, LastModifiedMixin):
     '''Blog post detail view'''
 
-    context_object_name = "post"
+    context_object_name = "page"
 
     def get_context_data(self, *args, **kwargs):
         """Add next/previous post to context."""

--- a/cdhweb/events/exodus.py
+++ b/cdhweb/events/exodus.py
@@ -3,9 +3,11 @@ import logging
 
 from mezzanine.core.models import CONTENT_STATUS_PUBLISHED
 
-from cdhweb.events.models import Event, EventsLinkPage, OldEvent, Speaker
-from cdhweb.pages.exodus import (convert_slug, exodize_attachments, exodize_history,
-                                 get_wagtail_image, to_streamfield)
+from cdhweb.events.models import (Event, EventsLinkPage, EventTag, OldEvent,
+                                  Speaker)
+from cdhweb.pages.exodus import (convert_slug, exodize_attachments,
+                                 exodize_history, get_wagtail_image,
+                                 to_streamfield)
 from cdhweb.people.models import Person
 
 
@@ -60,4 +62,7 @@ def event_exodus():
         exodize_attachments(event, event_page)
         exodize_history(event, event_page)
         
-        # NOTE no tags to migrate
+        # exodize tags
+        for tag in event.tags.all():
+            logging.debug("exodizing event tag %s" % tag)
+            EventTag.objects.create(content_object=event_page, tag=tag)

--- a/cdhweb/events/models.py
+++ b/cdhweb/events/models.py
@@ -305,8 +305,6 @@ class Event(BasePage, ClusterableModel):
     # custom manager/queryset logic
     objects = EventManager()
 
-    context_object_name = "event"
-
     class Meta:
         ordering = ("-start_time",)
 

--- a/cdhweb/events/templates/events/event.html
+++ b/cdhweb/events/templates/events/event.html
@@ -1,8 +1,6 @@
 {% extends 'base.html' %}
 {% load wagtailcore_tags wagtailimages_tags %}
 
-{% block page-subtitle %}{{ page.title }} | Events | {% endblock %}
-
 {% block extra-head %}
     <meta name="twitter:label1" content="Date"/>
     <meta name="twitter:data1" content="{{ page.when }}"/>

--- a/cdhweb/events/templates/events/event.html
+++ b/cdhweb/events/templates/events/event.html
@@ -1,14 +1,14 @@
 {% extends 'base.html' %}
 {% load wagtailcore_tags wagtailimages_tags %}
 
-{% block page-subtitle %}{{ event.title }} | Events | {% endblock %}
+{% block page-subtitle %}{{ page.title }} | Events | {% endblock %}
 
 {% block extra-head %}
     <meta name="twitter:label1" content="Date"/>
-    <meta name="twitter:data1" content="{{ event.when }}"/>
-    {% if event.location %}
+    <meta name="twitter:data1" content="{{ page.when }}"/>
+    {% if page.location %}
     <meta name="twitter:label2" content="Location"/>
-    <meta name="twitter:data2" content="{{ event.location.display_name }}"/>
+    <meta name="twitter:data2" content="{{ page.location.display_name }}"/>
     {% endif %}
 {% endblock %}
 
@@ -16,13 +16,13 @@
 {% block main %}
 <div typeof="schema:Event" class="event-detail">
 <header>
-    <h1 property="schema:name">{{ event.title }}</h1>
+    <h1 property="schema:name">{{ page.title }}</h1>
 </header>
 
 <div class="details">
-    {% if event.speakers.exists %}
+    {% if page.speakers.exists %}
     <ul>
-    {% for speaker in event.speakers.all %}
+    {% for speaker in page.speakers.all %}
     {# performer == presenter #}
     <li property="schema:performer" typeof="schema:Person">
         <h3><a property="schema:name"
@@ -38,39 +38,39 @@
     </ul>
     {% endif %}
     {# don't repeat event type if it is an exact match (i.e. reading group) #}
-    {% if event.type.name != event.title %}
-    <p>{{ event.type }}</p>
+    {% if page.type.name != page.title %}
+    <p>{{ page.type }}</p>
     {% endif %}
-    <meta property="schema:startDate" content="{{ event.start_time|date:'c' }}"/>
-    <meta property="schema:endDate" content="{{ event.end_time|date:'c' }}"/>
-    <div>{{ event.when }}</div>
+    <meta property="schema:startDate" content="{{ page.start_time|date:'c' }}"/>
+    <meta property="schema:endDate" content="{{ page.end_time|date:'c' }}"/>
+    <div>{{ page.when }}</div>
 
-    {% if event.location %}
-    <div property="schema:location" typeof="{% if event.is_virtual %}schema:VirtualLocation{% else %}schema:Place{% endif %}" class="location">
-        <span property="schema:name">{{ event.location.name }}</span>
-        {% if not event.is_virtual %}
+    {% if page.location %}
+    <div property="schema:location" typeof="{% if page.is_virtual %}schema:VirtualLocation{% else %}schema:Place{% endif %}" class="location">
+        <span property="schema:name">{{ page.location.name }}</span>
+        {% if not page.is_virtual %}
         <div property="schema:address"
-        {% if event.location.name == event.location.address %}style="display:none"{% endif %}>
-        {{ event.location.address}}</div>
-        {% elif event.join_url %}
-        <div property="schema:url" style="display:none">{{ event.join_url }}</div>
+        {% if page.location.name == page.location.address %}style="display:none"{% endif %}>
+        {{ page.location.address}}</div>
+        {% elif page.join_url %}
+        <div property="schema:url" style="display:none">{{ page.join_url }}</div>
         {% endif %}
     </div>
     {% endif %}
 
     <div class="ical">
-        <p><a href="{{ event.get_ical_url }}">Export to iCal</a></p>
+        <p><a href="{{ page.get_ical_url }}">Export to iCal</a></p>
     </div>
 </div>
 
 <div class="description">
-    {% if event.image %}
-        {% image event.image width-735 as event_img %}
-        <img src="{{ event_img.url }}" alt="{{ event.title }}" property="schema:image"/>
+    {% if page.image %}
+        {% image page.image width-735 as event_img %}
+        <img src="{{ event_img.url }}" alt="{{ page.title }}" property="schema:image"/>
     {% endif %}
-    <meta property="schema:url" content="{{ event.full_url }}"/>
+    <meta property="schema:url" content="{{ page.full_url }}"/>
     <div property="schema:description">
-    {% include_block event.body %}
+    {% include_block page.body %}
     </div>
 </div>
 

--- a/cdhweb/events/templates/events/event_archive.html
+++ b/cdhweb/events/templates/events/event_archive.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block page-subtitle %}{{ title|default:'Upcoming' }} Events | {% endblock %}
+{% block page-title %}{{ title|default:'Upcoming' }} Events{% endblock %}
 {% block bodyattrs %}class="with-cards"{% endblock %}
 
 {% block main %}

--- a/cdhweb/events/templates/events/event_archive.html
+++ b/cdhweb/events/templates/events/event_archive.html
@@ -33,7 +33,7 @@
 </section>
 {% endif %}
 
-{% for page in events %}
+{% for event in events %}
     {% include 'events/snippets/event_card.html' %}
 {% empty %}
     {# semester event archive will 404 for no events; upcoming does not #}
@@ -55,7 +55,7 @@
 
 {% if past.exists %}
 <h2>Past Events</h2>
-    {% for page in past reversed %}  {# display in chronological order #}
+    {% for event in past reversed %}  {# display in chronological order #}
         {% include 'events/snippets/event_card.html' %}
     {% endfor %}
 {% endif %}

--- a/cdhweb/events/templates/events/event_archive.html
+++ b/cdhweb/events/templates/events/event_archive.html
@@ -33,7 +33,7 @@
 </section>
 {% endif %}
 
-{% for event in events %}
+{% for page in events %}
     {% include 'events/snippets/event_card.html' %}
 {% empty %}
     {# semester event archive will 404 for no events; upcoming does not #}
@@ -55,7 +55,7 @@
 
 {% if past.exists %}
 <h2>Past Events</h2>
-    {% for event in past reversed %}  {# display in chronological order #}
+    {% for page in past reversed %}  {# display in chronological order #}
         {% include 'events/snippets/event_card.html' %}
     {% endfor %}
 {% endif %}

--- a/cdhweb/events/templates/events/snippets/event_card.html
+++ b/cdhweb/events/templates/events/snippets/event_card.html
@@ -1,49 +1,49 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 {# display a single event in card format #}
 {# FIXME: significant overlap with event_detail, esp. for schema properties #}
-{% if page.thumbnail %}
-    {% image page.thumbnail max-310x240 as event_thumb %}
+{% if event.thumbnail %}
+    {% image event.thumbnail max-310x240 as event_thumb %}
 {% endif %}
 <div class="card event" typeof="schema:Event">
-    <a property="schema:url" href="{{ page.get_url }}">
-        <div class="event-type">{{ page.type }}</div>
-        <div class="image" {% if page.thumbnail %}style="background-image:url('{{ event_thumb.url }}')"{% endif %}></div>
+    <a property="schema:url" href="{{ event.get_url }}">
+        <div class="event-type">{{ event.type }}</div>
+        <div class="image" {% if event.thumbnail %}style="background-image:url('{{ event_thumb.url }}')"{% endif %}></div>
         <div class="content">
-            <h2 property="schema:name">{{ page.title }}</h2>
+            <h2 property="schema:name">{{ event.title }}</h2>
             <div class="presenter">
-                {% for speaker in page.speakers.all %}
+                {% for speaker in event.speakers.all %}
                 <div property="schema:performer" typeof="schema:Person">
                     <span property="schema:name">{{ speaker.person }}</span>
                 </div>
                 {% endfor %}
             </div>
-            <meta property="schema:startDate" content="{{ page.start_time|date:'c' }}"/>
-            <meta property="schema:endDate" content="{{ page.end_time|date:'c' }}"/>
+            <meta property="schema:startDate" content="{{ event.start_time|date:'c' }}"/>
+            <meta property="schema:endDate" content="{{ event.end_time|date:'c' }}"/>
             {# location is required for schema.org #}
-            <div property="schema:location" typeof="{% if page.is_virtual %}schema:VirtualLocation{% else %}schema:Place{% endif %}">
-                <meta property="schema:name" content="{{ page.location.name }}"/>
-                {% if not page.is_virtual %}
-                <meta property="schema:address" content="{{ page.location.address }}"/>
-                {% elif page.join_url %}
-                <meta property="schema:url" content="{{ page.join_url }}"/>
+            <div property="schema:location" typeof="{% if event.is_virtual %}schema:VirtualLocation{% else %}schema:Place{% endif %}">
+                <meta property="schema:name" content="{{ event.location.name }}"/>
+                {% if not event.is_virtual %}
+                <meta property="schema:address" content="{{ event.location.address }}"/>
+                {% elif event.join_url %}
+                <meta property="schema:url" content="{{ event.join_url }}"/>
                 {% endif %}
             </div>
         </div>
         <div class="when">
             {# if duration is more than one day, display start/end days #}
-            <span class="day">{{ page.start_time|date:"F j" }}
+            <span class="day">{{ event.start_time|date:"F j" }}
                 {# display date range for multiday event #}
-                {% if page.duration.days >= 1 %} -
-                {% if page.start_time.month != page.end_time.month %}{{ page.end_time|date:"F" }}{% endif %}
-                {{ page.end_time|date:"j" }}
+                {% if event.duration.days >= 1 %} -
+                {% if event.start_time.month != event.end_time.month %}{{ event.end_time|date:"F" }}{% endif %}
+                {{ event.end_time|date:"j" }}
                 {% endif %}
             </span>
             {# do not display time on card for multiday event #}
-            {% if page.duration.days < 1 %}
-            <span class="time">{{ page.start_time|date:"g:i" }}–{{ page.end_time|date:"g:i A" }}</span>
+            {% if event.duration.days < 1 %}
+            <span class="time">{{ event.start_time|date:"g:i" }}–{{ event.end_time|date:"g:i A" }}</span>
             {% endif %}
         </div>
     </a>
     {# description is recommended for schema.org #}
-    <div style="display:none" property="schema:description">{{ page.search_description }}</div>
+    <div style="display:none" property="schema:description">{{ event.search_description }}</div>
 </div>

--- a/cdhweb/events/templates/events/snippets/event_card.html
+++ b/cdhweb/events/templates/events/snippets/event_card.html
@@ -1,49 +1,49 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 {# display a single event in card format #}
 {# FIXME: significant overlap with event_detail, esp. for schema properties #}
-{% if event.thumbnail %}
-    {% image event.thumbnail max-310x240 as event_thumb %}
+{% if page.thumbnail %}
+    {% image page.thumbnail max-310x240 as event_thumb %}
 {% endif %}
 <div class="card event" typeof="schema:Event">
-    <a property="schema:url" href="{{ event.get_url }}">
-        <div class="event-type">{{ event.type }}</div>
-        <div class="image" {% if event.thumbnail %}style="background-image:url('{{ event_thumb.url }}')"{% endif %}></div>
+    <a property="schema:url" href="{{ page.get_url }}">
+        <div class="event-type">{{ page.type }}</div>
+        <div class="image" {% if page.thumbnail %}style="background-image:url('{{ event_thumb.url }}')"{% endif %}></div>
         <div class="content">
-            <h2 property="schema:name">{{ event.title }}</h2>
+            <h2 property="schema:name">{{ page.title }}</h2>
             <div class="presenter">
-                {% for speaker in event.speakers.all %}
+                {% for speaker in page.speakers.all %}
                 <div property="schema:performer" typeof="schema:Person">
                     <span property="schema:name">{{ speaker.person }}</span>
                 </div>
                 {% endfor %}
             </div>
-            <meta property="schema:startDate" content="{{ event.start_time|date:'c' }}"/>
-            <meta property="schema:endDate" content="{{ event.end_time|date:'c' }}"/>
+            <meta property="schema:startDate" content="{{ page.start_time|date:'c' }}"/>
+            <meta property="schema:endDate" content="{{ page.end_time|date:'c' }}"/>
             {# location is required for schema.org #}
-            <div property="schema:location" typeof="{% if event.is_virtual %}schema:VirtualLocation{% else %}schema:Place{% endif %}">
-                <meta property="schema:name" content="{{ event.location.name }}"/>
-                {% if not event.is_virtual %}
-                <meta property="schema:address" content="{{ event.location.address }}"/>
-                {% elif event.join_url %}
-                <meta property="schema:url" content="{{ event.join_url }}"/>
+            <div property="schema:location" typeof="{% if page.is_virtual %}schema:VirtualLocation{% else %}schema:Place{% endif %}">
+                <meta property="schema:name" content="{{ page.location.name }}"/>
+                {% if not page.is_virtual %}
+                <meta property="schema:address" content="{{ page.location.address }}"/>
+                {% elif page.join_url %}
+                <meta property="schema:url" content="{{ page.join_url }}"/>
                 {% endif %}
             </div>
         </div>
         <div class="when">
             {# if duration is more than one day, display start/end days #}
-            <span class="day">{{ event.start_time|date:"F j" }}
+            <span class="day">{{ page.start_time|date:"F j" }}
                 {# display date range for multiday event #}
-                {% if event.duration.days >= 1 %} -
-                {% if event.start_time.month != event.end_time.month %}{{ event.end_time|date:"F" }}{% endif %}
-                {{ event.end_time|date:"j" }}
+                {% if page.duration.days >= 1 %} -
+                {% if page.start_time.month != page.end_time.month %}{{ page.end_time|date:"F" }}{% endif %}
+                {{ page.end_time|date:"j" }}
                 {% endif %}
             </span>
             {# do not display time on card for multiday event #}
-            {% if event.duration.days < 1 %}
-            <span class="time">{{ event.start_time|date:"g:i" }}–{{ event.end_time|date:"g:i A" }}</span>
+            {% if page.duration.days < 1 %}
+            <span class="time">{{ page.start_time|date:"g:i" }}–{{ page.end_time|date:"g:i A" }}</span>
             {% endif %}
         </div>
     </a>
     {# description is recommended for schema.org #}
-    <div style="display:none" property="schema:description">{{ event.search_description }}</div>
+    <div style="display:none" property="schema:description">{{ page.search_description }}</div>
 </div>

--- a/cdhweb/pages/templates/cdhpages/content_page.html
+++ b/cdhweb/pages/templates/cdhpages/content_page.html
@@ -1,8 +1,6 @@
 {% extends 'base.html' %}
 {% load wagtailcore_tags %}
 
-{% block page-title %}{{ page.seo_title }}{% endblock %}
-
 {% block bodyattrs %}class="richtextpage"{% endblock %}
 
 {% block main %}

--- a/cdhweb/pages/templates/cdhpages/home_page.html
+++ b/cdhweb/pages/templates/cdhpages/home_page.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load wagtailcore_tags %}
 
-{% block page-title %}{{ page.seo_title }}{% endblock %}
+{% block page-title %}Home{% endblock %}
 
 {% block content %} {# add a class to main content for home-page specific styles #}
 <div class="homepage{% if updates %} with-carousel{% endif %}">

--- a/cdhweb/pages/templates/cdhpages/home_page.html
+++ b/cdhweb/pages/templates/cdhpages/home_page.html
@@ -27,7 +27,7 @@
 
 <section class="events">
 <h2><a href="{% url 'event:upcoming' %}">Upcoming Events</a></h2>
-{% for event in events %}
+{% for page in events %}
     {% include 'events/snippets/event_card.html' %}
 {% empty %}
     <div>
@@ -39,7 +39,7 @@
 
 <section class="projects">
 <h2><a href="{% slugurl 'projects' %}">Projects</a></h2>
-{% for project in projects %}
+{% for page in projects %}
     {% include 'projects/snippets/project_card.html' %}
 {% endfor %}
 </section>

--- a/cdhweb/pages/templates/cdhpages/home_page.html
+++ b/cdhweb/pages/templates/cdhpages/home_page.html
@@ -1,7 +1,8 @@
 {% extends 'base.html' %}
 {% load wagtailcore_tags %}
 
-{% block page-title %}Home{% endblock %}
+{# Override entire title so there's no extra context appended #}
+{% block title %}<title>{% firstof page.seo_title page.title %}</title>{% endblock %}
 
 {% block content %} {# add a class to main content for home-page specific styles #}
 <div class="homepage{% if updates %} with-carousel{% endif %}">
@@ -19,15 +20,13 @@
 {# display editable page content; wrapped for formatting reasons #}
 <section>
     <div class="richtext">
-    {% for block in page.body %}
-        {% include_block block %}
-    {% endfor %}
+    {% include_block page.body %}
     </div>
 </section>
 
 <section class="events">
 <h2><a href="{% url 'event:upcoming' %}">Upcoming Events</a></h2>
-{% for page in events %}
+{% for event in events %}
     {% include 'events/snippets/event_card.html' %}
 {% empty %}
     <div>
@@ -39,7 +38,7 @@
 
 <section class="projects">
 <h2><a href="{% slugurl 'projects' %}">Projects</a></h2>
-{% for page in projects %}
+{% for project in projects %}
     {% include 'projects/snippets/project_card.html' %}
 {% endfor %}
 </section>

--- a/cdhweb/pages/templates/cdhpages/landing_page.html
+++ b/cdhweb/pages/templates/cdhpages/landing_page.html
@@ -21,7 +21,7 @@ S @1x W: 736px H: 320px, @2x W: 1472px H: 640px
 <header {% if page.header_image %}style="background-image:url('{{ header_img.url }}')"
     {% else %}class="no-background"{% endif %}>
     <div>
-    <a href="{% pageurl site.root_page %}" class="home">/</a><h1>{{ page.title }}</h1>
+    <a href="{% pageurl site.root_page %}" class="home" alt="home">/</a><h1>{{ page.title }}</h1>
     <p>{{ page.tagline }}</p>
     </div>
 </header>

--- a/cdhweb/pages/templates/cdhpages/landing_page.html
+++ b/cdhweb/pages/templates/cdhpages/landing_page.html
@@ -1,8 +1,6 @@
 {% extends 'base.html' %}
 {% load wagtailcore_tags wagtailimages_tags %}
 
-{% block page-title %}{{ page.title }}{% endblock %}
-
 {% block bodyattrs %}class="with-cards small-no-cards"{% endblock %}
 
 {% block content %} {# wrap content in an article tag #}

--- a/cdhweb/people/models.py
+++ b/cdhweb/people/models.py
@@ -445,8 +445,6 @@ class Profile(BasePage):
     parent_page_types = ["people.PeopleLandingPage"]
     subpage_types = []
 
-    context_object_name = "profile"
-
     def get_context(self, request):
         """Add recent BlogPosts by this Person to their Profile."""
         context = super().get_context(request)

--- a/cdhweb/people/templates/people/person_list.html
+++ b/cdhweb/people/templates/people/person_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block page-subtitle %}{{ title|default:"People" }} | {% endblock %}
+{% block page-title %}{{ title|default:"People" }}{% endblock %}
 {% block bodyattrs %}class="with-cards"{% endblock %}
 
 {% block main %}

--- a/cdhweb/people/templates/people/profile.html
+++ b/cdhweb/people/templates/people/profile.html
@@ -1,14 +1,14 @@
 {% extends 'base.html' %}
 {% load wagtailcore_tags wagtailimages_tags %}
 
-{% block page-subtitle %}{{ profile.title }} | People | {% endblock %}
+{% block page-subtitle %}{{ page.title }} | People | {% endblock %}
 
 {% block main %}
 <div class="profile">
 <header>
-    <h1>{{ profile.title }}</h1>
+    <h1>{{ page.title }}</h1>
     {# display all positions, current first; dates for non-current #}
-    {% for position in profile.person.positions.all %}
+    {% for position in page.person.positions.all %}
         <p class="title">{% if not position.is_current %}
             {{ position.start_date.year }}{% if position.end_date.year != position.start_date.year%}-{{ position.end_date.year }}{% endif %}
             {% endif %}
@@ -20,30 +20,30 @@
 <div class="links">
     {# NOTE equiv to contributors in project #}
     <ul>
-    {% for link in profile.person.related_links.all %}
+    {% for link in page.person.related_links.all %}
         <li><a href="{{ link.url }}">{{ link.type.name }}</a></li>
     {% endfor %}
     </ul>
 </div>
 
-{% if profile.image %}
-    {% image profile.image fill-790x632 as profile_img %}
-    <img src="{{ profile_img.url }}" alt="{{ profile.title }}"/>
+{% if page.image %}
+    {% image page.image fill-790x632 as profile_img %}
+    <img src="{{ profile_img.url }}" alt="{{ page.title }}"/>
 {% endif %}
 
 <div class="education">
-    {{ profile.education|richtext }}
-    <a href="mailto:{{ profile.person.email }}">{{ profile.person.email }}</a>
-    {% if profile.person.phone_number %}
-        <p>{{ profile.person.phone_number }}</p>
+    {{ page.education|richtext }}
+    <a href="mailto:{{ page.person.email }}">{{ page.person.email }}</a>
+    {% if page.person.phone_number %}
+        <p>{{ page.person.phone_number }}</p>
     {% endif %}
-    {% if profile.person.office_location %}
-        <p>{{ profile.person.office_location }}</p>
+    {% if page.person.office_location %}
+        <p>{{ page.person.office_location }}</p>
     {% endif %}
 </div>
 
 <div class="bio">
-    {% include_block profile.body %}
+    {% include_block page.body %}
 </div>
 
 {% if recent_posts %}

--- a/cdhweb/people/templates/people/profile.html
+++ b/cdhweb/people/templates/people/profile.html
@@ -1,8 +1,6 @@
 {% extends 'base.html' %}
 {% load wagtailcore_tags wagtailimages_tags %}
 
-{% block page-subtitle %}{{ page.title }} | People | {% endblock %}
-
 {% block main %}
 <div class="profile">
 <header>

--- a/cdhweb/projects/exodus.py
+++ b/cdhweb/projects/exodus.py
@@ -6,7 +6,8 @@ from mezzanine.core.models import CONTENT_STATUS_PUBLISHED
 from cdhweb.pages.exodus import (convert_slug, exodize_attachments,
                                  exodize_history, get_wagtail_image,
                                  to_streamfield)
-from cdhweb.projects.models import OldProject, Project, ProjectsLandingPage
+from cdhweb.projects.models import (OldProject, Project, ProjectsLandingPage,
+                                    ProjectTag)
 
 
 def project_exodus():
@@ -70,4 +71,7 @@ def project_exodus():
         exodize_attachments(project, project_page)
         exodize_history(project, project_page)
         
-        # NOTE no tags to migrate
+        # exodize tags
+        for tag in project.tags.all():
+            logging.debug("exodizing project tag %s" % tag)
+            ProjectTag.objects.create(content_object=project_page, tag=tag)

--- a/cdhweb/projects/models.py
+++ b/cdhweb/projects/models.py
@@ -234,8 +234,6 @@ class Project(BasePage, ClusterableModel):
     # custom manager/queryset logic
     objects = ProjectManager()
 
-    context_object_name = "project"
-
     def __str__(self):
         return self.title
 

--- a/cdhweb/projects/templates/projects/project.html
+++ b/cdhweb/projects/templates/projects/project.html
@@ -1,18 +1,18 @@
 {% extends 'base.html' %}
 {% load wagtailcore_tags wagtailimages_tags %}
 
-{% block page-subtitle %}{{ project.title }} | Projects | {% endblock %}
+{% block page-subtitle %}{{ page.title }} | Projects | {% endblock %}
 
 {% block main %}
 <div class="project-detail">
 <header>
-    <h1>{{ project.title }}</h1>
-    <p class="short_description">{{ project.short_description }}</p>
+    <h1>{{ page.title }}</h1>
+    <p class="short_description">{{ page.short_description }}</p>
 </header>
 
 <div class="links">
   <ul>
-    {% for link in project.related_links.all %}
+    {% for link in page.related_links.all %}
         {% with link_type=link.type.name %}
         <li class="{{ link_type|lower }}"><a href="{{ link.url }}">
             {# Special case: display project URL to make it visible & memorable  #}
@@ -27,29 +27,29 @@
 <div class="contributors">
     <ul>
     {# display project members for the current (or most recent) grant #}
-    {% for membership in project.current_memberships %}
+    {% for membership in page.current_memberships %}
     {# TODO: can we pluralize by checking role for next item in index? #}
         {% ifchanged %}<li class="role"><h3>{{ membership.role }}</h3></li>{% endifchanged %}
         {% include 'projects/snippets/project_membership.html' with member=membership.person %}
     {% endfor %}
     {# include project alumni  #}
-    {% if project.alums %}
-        <li class="role"><h3>Project Alum{{ project.alums|pluralize }}</h3></li>
-        {% for member in project.alums %}
+    {% if page.alums %}
+        <li class="role"><h3>Project Alum{{ page.alums|pluralize }}</h3></li>
+        {% for member in page.alums %}
             {% include 'projects/snippets/project_membership.html' %}
         {% endfor %}
     {% endif %}
     </ul>
-{% if project.cdh_built %}<div class="cdh-built">Built by CDH</div>{% endif %}
+{% if page.cdh_built %}<div class="cdh-built">Built by CDH</div>{% endif %}
 </div>
 
 <div class="description">
-    {% if project.image %}
-        {% image project.image width-735 as project_img %}
-        <img src="{{ project_img.url }}" alt="{{ project.title }}"/>
+    {% if page.image %}
+        {% image page.image width-735 as project_img %}
+        <img src="{{ project_img.url }}" alt="{{ page.title }}"/>
     {% endif %}
-    {% include_block project.body %}
-    {% if project.grants.exists %}
+    {% include_block page.body %}
+    {% if page.grants.exists %}
     <section class="grant-history">
         <h2>CDH Grant History</h2>
         <ul>
@@ -57,7 +57,7 @@
             FakeQuerySet doesn't support .reverse() so we have to use .all()
             with 'reversed' instead of .reverse() when the page is previewed
             {% endcomment %}
-            {% for grant in project.grants.all reversed %}
+            {% for grant in page.grants.all reversed %}
             <li>{{ grant.years }} {{ grant.grant_type }}</li>
             {% endfor %}
         </ul>

--- a/cdhweb/projects/templates/projects/project.html
+++ b/cdhweb/projects/templates/projects/project.html
@@ -1,8 +1,6 @@
 {% extends 'base.html' %}
 {% load wagtailcore_tags wagtailimages_tags %}
 
-{% block page-subtitle %}{{ page.title }} | Projects | {% endblock %}
-
 {% block main %}
 <div class="project-detail">
 <header>

--- a/cdhweb/projects/templates/projects/project_list.html
+++ b/cdhweb/projects/templates/projects/project_list.html
@@ -29,13 +29,13 @@
 {% endif %}
 
 {# current projects #}
-{% for page in current %}
+{% for project in current %}
     {% include 'projects/snippets/project_card.html' with large=1 %}
 {% endfor %}
 
 {% if past %} {# display past if any #}
 <h2>{{ past_title }}</h2>
-{% for page in past %}
+{% for project in past %}
     {% include 'projects/snippets/project_card.html' with large=1 %}
 {% endfor %}
 {% endif %}

--- a/cdhweb/projects/templates/projects/project_list.html
+++ b/cdhweb/projects/templates/projects/project_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block page-subtitle %}{{ title }} | {% endblock %}
+{% block page-title %}{{ title|default:'People' }}{% endblock %}
 {% block bodyattrs %}class="with-cards"{% endblock %}
 
 {% block main %}

--- a/cdhweb/projects/templates/projects/project_list.html
+++ b/cdhweb/projects/templates/projects/project_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block page-title %}{{ title|default:'People' }}{% endblock %}
+{% block page-title %}{{ title|default:'Projects' }}{% endblock %}
 {% block bodyattrs %}class="with-cards"{% endblock %}
 
 {% block main %}

--- a/cdhweb/projects/templates/projects/project_list.html
+++ b/cdhweb/projects/templates/projects/project_list.html
@@ -29,13 +29,13 @@
 {% endif %}
 
 {# current projects #}
-{% for project in current %}
+{% for page in current %}
     {% include 'projects/snippets/project_card.html' with large=1 %}
 {% endfor %}
 
 {% if past %} {# display past if any #}
 <h2>{{ past_title }}</h2>
-{% for project in past %}
+{% for page in past %}
     {% include 'projects/snippets/project_card.html' with large=1 %}
 {% endfor %}
 {% endif %}

--- a/cdhweb/projects/templates/projects/snippets/project_card.html
+++ b/cdhweb/projects/templates/projects/snippets/project_card.html
@@ -1,17 +1,17 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 {# default card display for a project #}
-{% if page.thumbnail %}
-    {% image page.thumbnail max-310x240 as project_thumb %}
+{% if project.thumbnail %}
+    {% image project.thumbnail max-310x240 as project_thumb %}
 {% endif %}
 <div class="card project {% if large %}project-large{% endif %}"
-{% if page.image %}style="background-image:url('{{ project_thumb.url }}')"{% endif %}>
-{% if page.cdh_built %}<div class="cdh-built">Built by CDH</div>{% endif %}
-{% if page.website_url %}<a class="external" title="Project Website" href="{{ page.website_url }}"> </a>{% endif %}
-    <a href="{{ page.get_url }}">
+{% if project.image %}style="background-image:url('{{ project_thumb.url }}')"{% endif %}>
+{% if project.cdh_built %}<div class="cdh-built">Built by CDH</div>{% endif %}
+{% if project.website_url %}<a class="external" title="Project Website" href="{{ project.website_url }}"> </a>{% endif %}
+    <a href="{{ project.get_url }}">
     <div class="content">
-        <h2>{{ page.title|safe }}</h2>
-        <p>{{ page.short_description|safe }}</p>
+        <h2>{{ project.title|safe }}</h2>
+        <p>{{ project.short_description|safe }}</p>
     </div>
     </a>
 </div>

--- a/cdhweb/projects/templates/projects/snippets/project_card.html
+++ b/cdhweb/projects/templates/projects/snippets/project_card.html
@@ -1,17 +1,17 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 {# default card display for a project #}
-{% if project.thumbnail %}
-    {% image project.thumbnail max-310x240 as project_thumb %}
+{% if page.thumbnail %}
+    {% image page.thumbnail max-310x240 as project_thumb %}
 {% endif %}
 <div class="card project {% if large %}project-large{% endif %}"
-{% if project.image %}style="background-image:url('{{ project_thumb.url }}')"{% endif %}>
-{% if project.cdh_built %}<div class="cdh-built">Built by CDH</div>{% endif %}
-{% if project.website_url %}<a class="external" title="Project Website" href="{{ project.website_url }}"> </a>{% endif %}
-    <a href="{{ project.get_url }}">
+{% if page.image %}style="background-image:url('{{ project_thumb.url }}')"{% endif %}>
+{% if page.cdh_built %}<div class="cdh-built">Built by CDH</div>{% endif %}
+{% if page.website_url %}<a class="external" title="Project Website" href="{{ page.website_url }}"> </a>{% endif %}
+    <a href="{{ page.get_url }}">
     <div class="content">
-        <h2>{{ project.title|safe }}</h2>
-        <p>{{ project.short_description|safe }}</p>
+        <h2>{{ page.title|safe }}</h2>
+        <p>{{ page.short_description|safe }}</p>
     </div>
     </a>
 </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,9 @@
       gtag('config', 'UA-87887700-1', {'anonymize_ip': true});
     </script>
     {% endif %}
-    <title>{% block page-title %}{% if page %}{{ page.seo_title }}{% endif %}{% endblock %} – CDH@Princeton</title>
+    {% block title %}
+    <title>{% block page-title %}{% firstof page.seo_title page.title page_title %}{% endblock %} – CDH@Princeton</title>
+    {% endblock %}
     {% if SHOW_TEST_WARNING %} {# test variant favicon to help differentiate test/prod sites #}
     <link rel="shortcut icon" href="{% static 'favicon-test.ico' %}">
     {% else %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,11 +15,11 @@
       gtag('config', 'UA-87887700-1', {'anonymize_ip': true});
     </script>
     {% endif %}
-    <title>{% block page-title %}{% block page-subtitle %}{% if page %}{{ page.meta_title|add:" | "}}{% endif %}{% endblock %}The Center for Digital Humanities at Princeton{% endblock %}</title>
+    <title>{% block page-title %}{% if page %}{{ page.seo_title }}{% endif %}{% endblock %} – CDH@Princeton</title>
     {% if SHOW_TEST_WARNING %} {# test variant favicon to help differentiate test/prod sites #}
-    <link rel="shortcut icon" href="{%  static 'favicon-test.ico' %}">
+    <link rel="shortcut icon" href="{% static 'favicon-test.ico' %}">
     {% else %}
-    <link rel="shortcut icon" href="{%  static 'favicon.ico' %}">
+    <link rel="shortcut icon" href="{% static 'favicon.ico' %}">
     {% endif %}
     {% include 'snippets/head_meta.html' %}
     <meta name="google-site-verification" content="pS2kpksxg6JeC90IvA8BHVsFuK_6b7J_vARVLqqu7ck" />

--- a/templates/snippets/head_meta.html
+++ b/templates/snippets/head_meta.html
@@ -1,20 +1,20 @@
 {% load static cdh_tags %}
 {# html metadata #}
-    <meta name="keywords" content="{% block meta_keywords %}{{ page.keywords.all|join:', ' }}{% endblock %}"/>
-    <meta name="description" content="{% block meta_description %}{{ page.description }}{% endblock %}"/>
-    {# determine preview image: specified by page, cdh icon based on url, or default image #}
-    {% firstof preview_image page.get_absolute_url|url_to_icon_path default_preview_image as meta_preview_image %}
-    {# open graph metadata #}
-    <meta property="og:title" content="{{ page.meta_title }}" />
-    <meta property="og:type" content="{{ opengraph_type|default:'website' }}" />
-    <meta property="og:url" content="{{ request.build_absolute_uri }}" />
-    <meta property="og:image" content="{{ meta_preview_image }}" />
-    <meta property="og:description" content="{{ page.description }}"/>
-    <meta property="og:site_name" content="Center for Digital Humanities @ Princeton University"/>
-    {# twitter card #}
-    <meta name="twitter:card" content="{{ twitter_card_type|default:'summary' }}" />
-    <meta name="twitter:site" content="@PrincetonDH" />
-    <meta name="twitter:title" content="{{ page.meta_title }}"/>
-    <meta name="twitter:description" content="{{ page.description }}" />
-    <meta name="twitter:image" content="{% firstof twitter_image meta_preview_image %}" />
+<meta name="keywords" content="{{ page.tags.all|join:', ' }}"/>
+<meta name="description" content="{{ page.search_description }}"/>
+{# determine preview image: specified by page, cdh icon based on url, or default image #}
+{% firstof preview_image page.get_url|url_to_icon_path default_preview_image as meta_preview_image %}
+{# open graph metadata #}
+<meta property="og:title" content="{{ page.seo_title }}" />
+<meta property="og:type" content="{{ opengraph_type|default:'website' }}" />
+<meta property="og:url" content="{{ request.build_absolute_uri }}" />
+<meta property="og:image" content="{{ meta_preview_image }}" />
+<meta property="og:description" content="{{ page.search_description }}"/>
+<meta property="og:site_name" content="Center for Digital Humanities @ Princeton University"/>
+{# twitter card #}
+<meta name="twitter:card" content="{{ twitter_card_type|default:'summary' }}" />
+<meta name="twitter:site" content="@PrincetonDH" />
+<meta name="twitter:title" content="{{ page.seo_title }}"/>
+<meta name="twitter:description" content="{{ page.search_description }}" />
+<meta name="twitter:image" content="{% firstof twitter_image meta_preview_image %}" />
 

--- a/templates/snippets/head_meta.html
+++ b/templates/snippets/head_meta.html
@@ -1,5 +1,6 @@
 {% load static cdh_tags %}
 {# html metadata #}
+{% autoescape on %}
 {% if page.tags.exists %}<meta name="keywords" content="{{ page.tags.all|join:', ' }}"/>{% endif %}
 {% if page.search_description %}<meta name="description" content="{{ page.search_description }}"/>{% endif %}
 {# determine preview image: specified by page, cdh icon based on url, or default image #}
@@ -17,4 +18,4 @@
 <meta name="twitter:title" content="{% firstof page.seo_title page.title page_title %}"/>
 {% if page.search_description %}<meta name="twitter:description" content="{{ page.search_description }}"/>{% endif %}
 <meta name="twitter:image" content="{% firstof twitter_image meta_preview_image %}" />
-
+{% endautoescape %}

--- a/templates/snippets/head_meta.html
+++ b/templates/snippets/head_meta.html
@@ -1,20 +1,20 @@
 {% load static cdh_tags %}
 {# html metadata #}
-<meta name="keywords" content="{{ page.tags.all|join:', ' }}"/>
-<meta name="description" content="{{ page.search_description }}"/>
+{% if page.tags.exists %}<meta name="keywords" content="{{ page.tags.all|join:', ' }}"/>{% endif %}
+{% if page.search_description %}<meta name="description" content="{{ page.search_description }}"/>{% endif %}
 {# determine preview image: specified by page, cdh icon based on url, or default image #}
 {% firstof preview_image page.get_url|url_to_icon_path default_preview_image as meta_preview_image %}
 {# open graph metadata #}
-<meta property="og:title" content="{{ page.seo_title }}" />
+<meta property="og:title" content="{% firstof page.seo_title page.title page_title %}" />
 <meta property="og:type" content="{{ opengraph_type|default:'website' }}" />
 <meta property="og:url" content="{{ request.build_absolute_uri }}" />
 <meta property="og:image" content="{{ meta_preview_image }}" />
-<meta property="og:description" content="{{ page.search_description }}"/>
+{% if page.search_description %}<meta property="og:description" content="{{ page.search_description }}"/>{% endif %}
 <meta property="og:site_name" content="Center for Digital Humanities @ Princeton University"/>
 {# twitter card #}
 <meta name="twitter:card" content="{{ twitter_card_type|default:'summary' }}" />
 <meta name="twitter:site" content="@PrincetonDH" />
-<meta name="twitter:title" content="{{ page.seo_title }}"/>
-<meta name="twitter:description" content="{{ page.search_description }}" />
+<meta name="twitter:title" content="{% firstof page.seo_title page.title page_title %}"/>
+{% if page.search_description %}<meta name="twitter:description" content="{{ page.search_description }}"/>{% endif %}
 <meta name="twitter:image" content="{% firstof twitter_image meta_preview_image %}" />
 


### PR DESCRIPTION
- Use "page" context object naming everywhere for template compatibility
- Update <title> elements site-wide for brevity
- Update all <head> metadata, including keywords
- Exodize tags on projects, events, and blog posts so they can be used as keywords
