### PR TITLE
Fix active nav status

### DIFF
--- a/cdhweb/resources/templatetags/cdh_tags.py
+++ b/cdhweb/resources/templatetags/cdh_tags.py
@@ -36,6 +36,7 @@ def url_to_icon(value):
             return icon
     return ''
 
+
 @register.filter
 def url_to_icon_path(value):
     '''Return absolute path to CDH icon name based on URL.'''
@@ -43,3 +44,10 @@ def url_to_icon_path(value):
     if img:
         return absolutize_url('{}img/cdh-icons/png@2X/{}@2x.png'.format(settings.STATIC_URL, img))
     return ''
+
+
+@register.filter('startswith')
+def startswith(text, starts):
+    if isinstance(text, str):
+        return text.startswith(starts)
+    return False

--- a/cdhweb/resources/tests/test_tags.py
+++ b/cdhweb/resources/tests/test_tags.py
@@ -21,3 +21,9 @@ def test_url_to_icon_path():
     domain = Site.objects.get_current().domain
     assert cdh_tags.url_to_icon_path('/people/staff/') == \
         'https://{}/static/img/cdh-icons/png@2X/ppl@2x.png'.format(domain)
+
+
+def test_startswith():
+    assert cdh_tags.startswith('yes', 'y')
+    assert not cdh_tags.startswith('no', 'y')
+    assert not cdh_tags.startswith(3, 'y')

--- a/templates/snippets/navigation_card.html
+++ b/templates/snippets/navigation_card.html
@@ -1,4 +1,5 @@
 {# secondary and tertiary naviation for the top-level of the site #}
+{% load cdh_tags %}
 {% if navpages %}
 <div class="nav-card menu-{{ navpage.slug }}">
     <div class="inner">
@@ -10,7 +11,7 @@
                     href="{{ navpage.get_url }}"
                     tabindex="-1"
                     {% if navpage.get_children.live.in_menu %} aria-owns="{{ navpage.slug }}-tertiary"{% endif %}
-                    {% if navpage.get_url == request.path %} aria-current="page"{% endif %}>{{ navpage.title }}</a>
+                    {% if request.path|startswith:navpage.get_url %} aria-current="page"{% endif %}>{{ navpage.title }}</a>
                 {% include "snippets/tertiary_navigation.html" with navpages=navpage.get_children.live.in_menu %}
             </li>
         {% endfor %}

--- a/templates/snippets/primary_navigation.html
+++ b/templates/snippets/primary_navigation.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n cdh_tags %}
 {# top level menu, with secondary nav for current site section #}
 <div class="nav-main">
     {# top-level pages #}
@@ -17,7 +17,7 @@
                     aria-haspopup="true"
                     aria-expanded="false"
                     {% endif %}
-                    {% if navpage.get_url == request.path %} aria-current="page"{% endif %}>{{ navpage.title }}
+                    {% if request.path|startswith:navpage.get_url %} aria-current="page"{% endif %}>{{ navpage.title }}
                 </a>
             </li>
         {% endif %}


### PR DESCRIPTION
This addresses setting nav headings to active nav status based on current page being in the page hierarchy. It assumes hierarchy == page url, which I think under wagtail it does.

Suspect that at this point we should go ahead and treat this as a bug and include the fix in 3.0.1 vs trying to include in 3.0...