### PR TITLE
head meta 2

### DIFF
--- a/cdhweb/blog/templates/blog/blogpost_archive.html
+++ b/cdhweb/blog/templates/blog/blogpost_archive.html
@@ -1,15 +1,15 @@
 {% extends 'blog/base.html' %}
 {% load humanize %}
 
-{% block page-title %}{{ title|default:'Latest' }} Updates{% endblock %}
+{% block page-title %}{{ page_title }}{% endblock %}
 
 {% block main %}
 <section class="blogposts">
 
-<h1>{{ title|default:'Latest' }} Updates</h1>
+<h1>{{ page_title }}</h1>
 
 <div class="archive-nav">
-  <a class="toggle">Latest <i class="fa fa-chevron-down" aria-hidden="true"></i></a>
+  <a class="toggle">{{ page_title }} <i class="fa fa-chevron-down" aria-hidden="true"></i></a>
   <ul class="submenu">
     {# include latest blogposts page link #}
     {% url 'blog:list' as latest_url %}

--- a/cdhweb/blog/tests/test_views.py
+++ b/cdhweb/blog/tests/test_views.py
@@ -22,7 +22,7 @@ class TestBlogYearArchiveView:
     def test_title(self, client, blog_posts):
         """blog post year archive should add year to context as title"""
         response = client.get(reverse("blog:by-year", kwargs={"year": "2019"}))
-        assert response.context["title"] == "2019"
+        assert response.context["page_title"] == "2019 Updates"
 
 
 class TestBlogMonthArchiveView:
@@ -44,7 +44,7 @@ class TestBlogMonthArchiveView:
         """blog post year archive should add year/month to context as title"""
         response = client.get(reverse("blog:by-month",
                               kwargs={"year": "2019", "month": "03"}))
-        assert response.context["title"] == "March 2019"
+        assert response.context["page_title"] == "March 2019 Updates"
 
 
 class TestBlogPostDetailView:

--- a/cdhweb/blog/views.py
+++ b/cdhweb/blog/views.py
@@ -33,6 +33,13 @@ class BlogIndexView(BlogPostArchiveMixin, ArchiveIndexView):
     '''Main blog post list view'''
     date_list_period = 'month'
 
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context.update({
+            'page_title': "Latest Updates"
+        })
+        return context
+
 
 class BlogYearArchiveView(BlogPostArchiveMixin, YearArchiveView):
     '''Blog post archive by year'''
@@ -42,7 +49,7 @@ class BlogYearArchiveView(BlogPostArchiveMixin, YearArchiveView):
                         self).get_context_data(*args, **kwargs)
         context.update({
             'date_list': BlogPost.objects.dates(self.date_field, 'month', order='DESC'),
-            'title': self.kwargs['year']
+            'page_title': '%s Updates' % self.kwargs['year']
         })
         return context
 
@@ -58,7 +65,7 @@ class BlogMonthArchiveView(BlogPostArchiveMixin, MonthArchiveView):
         date = datetime.strptime('%(year)s %(month)s' % self.kwargs, '%Y %m')
         context.update({
             'date_list': BlogPost.objects.dates(self.date_field, 'month', order='DESC'),
-            'title': date.strftime('%B %Y')
+            'page_title': '%s Updates' % date.strftime('%B %Y')
         })
         return context
 

--- a/cdhweb/events/templates/events/event_archive.html
+++ b/cdhweb/events/templates/events/event_archive.html
@@ -1,16 +1,16 @@
 {% extends "base.html" %}
 
-{% block page-title %}{{ title|default:'Upcoming' }} Events{% endblock %}
+{% block page-title %}{{ page_title }}{% endblock %}
 {% block bodyattrs %}class="with-cards"{% endblock %}
 
 {% block main %}
 <section class="events">
 
-<h1>{{ title|default:'Upcoming' }} Events</h1>
+<h1>{{ page_title }}</h1>
 
 {# drop-down nav adapted from person list pages #}
 <div class="archive-nav">
-    <a class="toggle">{{ title|default:'Upcoming' }}
+    <a class="toggle">{{ page_title }}
         <i class="fa fa-chevron-down" aria-hidden="true"></i></a>
     <ul class="submenu">
     {# include upcoming events page link #}

--- a/cdhweb/events/views.py
+++ b/cdhweb/events/views.py
@@ -69,6 +69,7 @@ class UpcomingEventsView(EventMixinView, ArchiveIndexView, EventSemesterDates,
         event_qs = context['events']
         context.update({
             'events': event_qs.upcoming(),
+            'page_title': 'Upcoming Events',
             # find 6 most recent past events
             'past': event_qs.recent()[:6],
             'date_list': self.get_semester_date_list()
@@ -128,8 +129,8 @@ class EventSemesterArchiveView(EventMixinView, YearArchiveView,
         context = super(EventSemesterArchiveView,
                         self).get_context_data(*args, **kwargs)
         context.update({
-            'title': '%s %s' % (self.kwargs['semester'].title(),
-                                self.kwargs['year'])
+            'page_title': '%s %s Events' % (self.kwargs['semester'].title(),
+                                            self.kwargs['year'])
         })
         return context
 

--- a/cdhweb/pages/exodus.py
+++ b/cdhweb/pages/exodus.py
@@ -247,7 +247,7 @@ def create_link_page(page, parent):
     if page.richtextpage.content and \
             not is_blank(page.richtextpage.content):
         PageIntro.objects.create(page=new_page,
-                                 paragraph=page.richtextpage.content)
+                    paragraph=page.richtextpage.content.replace("&nbsp;", ""))
 
     return new_page
 

--- a/cdhweb/people/templates/people/person_list.html
+++ b/cdhweb/people/templates/people/person_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block page-title %}{{ title|default:"People" }}{% endblock %}
+{% block page-title %}{{ page_title }}{% endblock %}
 {% block bodyattrs %}class="with-cards"{% endblock %}
 
 {% block main %}
@@ -11,7 +11,7 @@
 
 {# drop-down nav adapted from events page #}
 <div class="archive-nav">
-  <a class="toggle">{{ title }}
+  <a class="toggle">{{ page_title }}
     <i class="fa fa-chevron-down" aria-hidden="true"></i></a>
   <ul class="submenu">
     {% for label, profile_url in archive_nav_urls %}

--- a/cdhweb/people/views.py
+++ b/cdhweb/people/views.py
@@ -57,7 +57,7 @@ class PersonListView(ListView, LastModifiedListMixin):
         context.update({
             'current': self.add_display_label(current),
             'past': self.add_display_label(past),
-            'title': self.page_title,
+            'page_title': self.page_title,
             'past_title': self.past_title,
             'current_title': self.current_title or self.page_title,  # use main title as default
             'archive_nav_urls': [

--- a/cdhweb/projects/templates/projects/project_list.html
+++ b/cdhweb/projects/templates/projects/project_list.html
@@ -1,16 +1,16 @@
 {% extends "base.html" %}
 
-{% block page-title %}{{ title|default:'Projects' }}{% endblock %}
+{% block page-title %}{{ page_title|default:'Projects' }}{% endblock %}
 {% block bodyattrs %}class="with-cards"{% endblock %}
 
 {% block main %}
 <section class="projects">
 
-<h1>{{ title }}</h1>
+<h1>{{ page_title }}</h1>
 
 {# drop-down nav adapted from person list pages #}
 <div class="archive-nav">
-  <a class="toggle">{{ title }}
+  <a class="toggle">{{ page_title }}
     <i class="fa fa-chevron-down" aria-hidden="true"></i></a>
   <ul class="submenu">
     {% for label, page_url in archive_nav_urls %}

--- a/cdhweb/projects/tests/test_views.py
+++ b/cdhweb/projects/tests/test_views.py
@@ -19,7 +19,7 @@ class TestProjectListView:
         view.dispatch(request)
         view.get_queryset()
         context = view.get_context_data(request=request)
-        assert context["title"] == "My Projects"
+        assert context["page_title"] == "My Projects"
         assert context["past_title"] == "My Past Projects"
 
     def test_archive_nav_urls(self, rf, projects):

--- a/cdhweb/projects/views.py
+++ b/cdhweb/projects/views.py
@@ -36,7 +36,7 @@ class ProjectListView(ListView, LastModifiedListMixin):
         context.update({
             "current": self.get_current(),
             "past": self.get_past(),
-            "title": self.page_title,
+            "page_title": self.page_title,
             "past_title": self.past_title,
             "archive_nav_urls": (
                 ("Sponsored Projects", reverse("projects:sponsored")),

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,7 +16,7 @@
     </script>
     {% endif %}
     {% block title %}
-    <title>{% block page-title %}{% firstof page.seo_title page.title page_title %}{% endblock %} – CDH@Princeton</title>
+    <title>{% block page-title %}{% firstof page_title page.seo_title page.title %}{% endblock %} – CDH@Princeton</title>
     {% endblock %}
     {% if SHOW_TEST_WARNING %} {# test variant favicon to help differentiate test/prod sites #}
     <link rel="shortcut icon" href="{% static 'favicon-test.ico' %}">

--- a/templates/snippets/head_meta.html
+++ b/templates/snippets/head_meta.html
@@ -1,7 +1,9 @@
 {% load static cdh_tags %}
 {% firstof preview_image page.get_url|url_to_icon_path default_preview_image as meta_preview_image %}
 {% firstof page_title page.seo_title page.title as meta_title %}
+{% autoescape off %}
 {% firstof page.get_plaintext_description page_intro.paragraph as meta_description %}
+{% endautoescape %}
 {% autoescape on %}
 {# html metadata #}
 {% if page.tags.exists %}<meta name="keywords" content="{{ page.tags.all|join:', ' }}"/>{% endif %}

--- a/templates/snippets/head_meta.html
+++ b/templates/snippets/head_meta.html
@@ -1,21 +1,23 @@
 {% load static cdh_tags %}
-{# html metadata #}
-{% autoescape on %}
-{% if page.tags.exists %}<meta name="keywords" content="{{ page.tags.all|join:', ' }}"/>{% endif %}
-{% if page.search_description %}<meta name="description" content="{{ page.search_description }}"/>{% endif %}
-{# determine preview image: specified by page, cdh icon based on url, or default image #}
 {% firstof preview_image page.get_url|url_to_icon_path default_preview_image as meta_preview_image %}
+{% firstof page_title page.seo_title page.title as meta_title %}
+{% firstof page.get_plaintext_description page_intro.paragraph as meta_description %}
+{% autoescape on %}
+{# html metadata #}
+{% if page.tags.exists %}<meta name="keywords" content="{{ page.tags.all|join:', ' }}"/>{% endif %}
+{% if meta_description %}<meta name="description" content="{{ meta_description|striptags }}"/>{% endif %}
+{# determine preview image: specified by page, cdh icon based on url, or default image #}
 {# open graph metadata #}
-<meta property="og:title" content="{% firstof page.seo_title page.title page_title %}" />
+<meta property="og:title" content="{{ meta_title }}" />
 <meta property="og:type" content="{{ opengraph_type|default:'website' }}" />
 <meta property="og:url" content="{{ request.build_absolute_uri }}" />
 <meta property="og:image" content="{{ meta_preview_image }}" />
-{% if page.search_description %}<meta property="og:description" content="{{ page.search_description }}"/>{% endif %}
-<meta property="og:site_name" content="Center for Digital Humanities @ Princeton University"/>
+{% if meta_description %}<meta property="og:description" content="{{ meta_description|striptags }}"/>{% endif %}
+<meta property="og:site_name" content="{{ site.root_page.seo_title }}"/>
 {# twitter card #}
 <meta name="twitter:card" content="{{ twitter_card_type|default:'summary' }}" />
 <meta name="twitter:site" content="@PrincetonDH" />
-<meta name="twitter:title" content="{% firstof page.seo_title page.title page_title %}"/>
-{% if page.search_description %}<meta name="twitter:description" content="{{ page.search_description }}"/>{% endif %}
+<meta name="twitter:title" content="{{ meta_title }}"/>
+{% if meta_description %}<meta name="twitter:description" content="{{ meta_description|striptags }}"/>{% endif %}
 <meta name="twitter:image" content="{% firstof twitter_image meta_preview_image %}" />
 {% endautoescape %}


### PR DESCRIPTION
- Use consistent context naming for page meta titles; remove defaults
- Reorder page title calculation logic in base template
- Add page intros as descriptions where present

this fixes issues with list views not having titles/descriptions defined. i made the views consistent across apps; there's no more default for view names (i think you're right that a default is not meaningful) and all views now use the context var `page_title` for the title you see in the h1, the dropdown selector, and the page's metadata.

everything is working except I can't get `striptags` to work on page intros; suspect it's because the object isn't playing nice with django templates. if I apply the filter in the `firstof`, it becomes the string `None` when not present.