### PR TITLE
Chore/cleanup migrated content

### DIFF
--- a/cdhweb/pages/management/commands/cleanup_migrated_content.py
+++ b/cdhweb/pages/management/commands/cleanup_migrated_content.py
@@ -77,7 +77,7 @@ class Command(BaseCommand):
                                 new_revision.publish()
 
                     if 'style="' in cleaned_html:
-                        inline_styles.append(page.get_full_url())
+                        inline_styles.append(realpage.get_full_url())
 
         if inline_styles:
             print('\nPages with inline styles:\n')

--- a/cdhweb/pages/management/commands/cleanup_migrated_content.py
+++ b/cdhweb/pages/management/commands/cleanup_migrated_content.py
@@ -8,6 +8,8 @@ class Command(BaseCommand):
 
     # list of regex patterns to replace with a single space
     re_to_space = [
+        # non-breaking space
+        re.compile(r'&nbsp;'),
         # two or more whitespaces
         re.compile(r'\s\s+'),
     ]
@@ -48,6 +50,7 @@ class Command(BaseCommand):
         v_normal = 1
         verbosity = options['verbosity']
         noact = options['noact']
+        inline_styles = []
         for page in Page.objects.all():
             realpage = page.get_specific()
             # skip pages with no body content
@@ -72,6 +75,13 @@ class Command(BaseCommand):
                         # publish new revision if the page is live
                         if realpage.live:
                                 new_revision.publish()
+
+                    if 'style="' in cleaned_html:
+                        inline_styles.append(page.get_full_url())
+
+        if inline_styles:
+            print('\nPages with inline styles:\n')
+            print('\n'.join(inline_styles))
 
     def clean_html(self, html):
         # remove these regexes

--- a/cdhweb/pages/management/commands/cleanup_migrated_content.py
+++ b/cdhweb/pages/management/commands/cleanup_migrated_content.py
@@ -1,0 +1,89 @@
+import re
+
+from django.core.management.base import BaseCommand
+from wagtail.core.models import Page
+
+
+class Command(BaseCommand):
+
+    # list of regex patterns to replace with a single space
+    re_to_space = [
+        # two or more whitespaces
+        re.compile(r'\s\s+'),
+    ]
+
+    # list of regex patterns to replace with first match
+    re_replace_g1 = [
+        # spans with no attributes
+        re.compile(r'<span>(((?!</span>).)*)</span>', flags=re.DOTALL),
+        # remove all but one space before open inline tag
+        re.compile(r'[\n ]+( <(a|em|b|strong|i|span))'),
+        # remove white space after end of open inline tag
+        re.compile(r'(<(a|em|b|strong|i|span)[^>]*>)[\n ]+'),
+        # remove white space before end inline tag
+        re.compile(r'[\n ]+(</(a|em|b|strong|i|span)[^>]*>)'),
+        # remove newline or whitespace between inline tag end and punctuation
+        re.compile(r'(</(a|em|b|strong|i|span)>)[\n ]+(?=[.,;])'),
+        # newline + whitespace after opening <p> or <div>
+        re.compile(r'(<p>|<div>)[\n ]+'),
+    ]
+
+    # list of regex patterns to remove
+    re_remove = [
+        # opening html & body tags
+        re.compile(r'^<html>\s*<body>\s'),
+        # closing html & body tags
+        re.compile(r'\s*</body>\s*</html>$'),
+        # empty div
+        re.compile(r'[\n ]+<div>\s*</div>'),
+    ]
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--noact", action="store_true", default=False,
+            help="Don't save any changes to the database"
+        )
+
+    def handle(self, *args, **options):
+        v_normal = 1
+        verbosity = options['verbosity']
+        noact = options['noact']
+        for page in Page.objects.all():
+            realpage = page.get_specific()
+            # skip pages with no body content
+            if not hasattr(realpage, 'body'):
+                continue
+            for block in realpage.body:
+                # assuming only one migrated block per page
+                if block.block_type == 'migrated':
+                    html = block.value.source
+                    cleaned_html = self.clean_html(html)
+                    block.value.source = cleaned_html
+                    if verbosity > v_normal:
+                        self.stdout.write(
+                            '\n\nHTML before cleanup for %s\n*****\n%s\n*****' %
+                            (page.get_full_url(), html))
+                        self.stdout.write(
+                            'HTML after cleanup:\n%s\n*****' % cleaned_html)
+
+                    # unless noact mode has been requested, save new revision
+                    if not noact:
+                        new_revision = realpage.save_revision()
+                        # publish new revision if the page is live
+                        if realpage.live:
+                                new_revision.publish()
+
+    def clean_html(self, html):
+        # remove these regexes
+        for regex in self.re_remove:
+            html = regex.sub('', html)
+
+        # replace these regexes with first match
+        for regex in self.re_replace_g1:
+            html = regex.sub(r'\1', html)
+
+        # replace these regexes with single space
+        for regex in self.re_to_space:
+            html = regex.sub(' ', html)
+
+        return html

--- a/cdhweb/pages/models.py
+++ b/cdhweb/pages/models.py
@@ -91,7 +91,8 @@ class BodyContentBlock(StreamBlock):
     #: approach; virtually all html tags are allowed. should NOT be used when
     #: creating new pages.
     migrated = RichTextBlock(
-        features=settings.RICHTEXT_ALLOWED_TAGS, icon="warning")
+        features=settings.RICHTEXT_ALLOWED_TAGS + PARAGRAPH_FEATURES +
+        ['image', 'embed'], icon="warning")
 
 
 class AttachmentBlock(StreamBlock):

--- a/cdhweb/settings.py
+++ b/cdhweb/settings.py
@@ -94,19 +94,20 @@ USE_MODELTRANSLATION = False
 # List of allowed tags in the rich text editor (tinyMCE). We need to add the
 # HTML5 <figcaption>, as it's not included by default.
 #
-RICHTEXT_ALLOWED_TAGS = ('a', 'abbr', 'acronym', 'address', 'area', 'article',
-                        'aside', 'b', 'bdo', 'big', 'blockquote', 'br',
-                        'button', 'caption', 'center', 'cite', 'code', 'col',
-                        'colgroup', 'dd', 'del', 'dfn', 'dir', 'div', 'dl',
-                        'dt', 'em', 'fieldset', 'figure', 'figcaption', 'font',
-                        'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-                        'header', 'hr', 'i', 'img', 'input', 'ins', 'kbd',
-                        'label', 'legend', 'li', 'map', 'men', 'nav', 'ol',
-                        'optgroup', 'option', 'p', 'pre', 'q', 's', 'samp',
-                        'section', 'select', 'small', 'span', 'strike',
-                        'strong', 'sub', 'sup', 'table', 'tbody', 'td',
-                        'textarea', 'tfoot', 'th', 'thead', 'tr', 'tt', '',
-                        'ul', 'var', 'wbr', 'iframe')
+RICHTEXT_ALLOWED_TAGS = [
+    'a', 'abbr', 'acronym', 'address', 'area', 'article',
+    'aside', 'b', 'bdo', 'big', 'blockquote', 'br',
+    'button', 'caption', 'center', 'cite', 'code', 'col',
+    'colgroup', 'dd', 'del', 'dfn', 'dir', 'div', 'dl',
+    'dt', 'em', 'fieldset', 'figure', 'figcaption', 'font',
+    'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'header', 'hr', 'i', 'img', 'input', 'ins', 'kbd',
+    'label', 'legend', 'li', 'map', 'men', 'nav', 'ol',
+    'optgroup', 'option', 'p', 'pre', 'q', 's', 'samp',
+    'section', 'select', 'small', 'span', 'strike',
+    'strong', 'sub', 'sup', 'table', 'tbody', 'td',
+    'textarea', 'tfoot', 'th', 'thead', 'tr', 'tt', '',
+    'ul', 'var', 'wbr', 'iframe']
 
 ####################
 # WAGTAIL SETTINGS #


### PR DESCRIPTION
- configures migrated text field to allow links, images embeds
- new one-time use manage command to clean up exodized rich text content to remove unwanted whitespace around inline tags, remove wrapping html/body tags, etc.