### PR TITLE
bug/318 page ordering

### DIFF
--- a/cdhweb/blog/wagtail_hooks.py
+++ b/cdhweb/blog/wagtail_hooks.py
@@ -18,6 +18,7 @@ class BlogPostAdmin(ThumbnailMixin, ModelAdmin):
     exclude_from_explorer = True
     thumb_image_field_name = "featured_image"
     thumb_col_header_text = "image"
+    ordering = ("-first_published_at",)
     list_per_page = 25
     menu_order = 210
 

--- a/cdhweb/events/models.py
+++ b/cdhweb/events/models.py
@@ -169,9 +169,6 @@ class Event(BasePage, ClusterableModel):
     # custom manager/queryset logic
     objects = EventManager()
 
-    class Meta:
-        ordering = ("-start_time",)
-
     def __str__(self):
         return " - ".join([self.title, self.start_time.strftime("%b %d, %Y")])
 

--- a/cdhweb/events/wagtail_hooks.py
+++ b/cdhweb/events/wagtail_hooks.py
@@ -20,6 +20,7 @@ class EventAdmin(ThumbnailMixin, ModelAdmin):
     exclude_from_explorer = True
     thumb_image_field_name = "thumbnail"
     thumb_col_header_text = "thumbnail"
+    ordering = ("-start_time",)
     list_per_page = 25
 
 

--- a/cdhweb/pages/models.py
+++ b/cdhweb/pages/models.py
@@ -242,7 +242,7 @@ class HomePage(BasePage):
         Event = apps.get_model("events", "event")
 
         # add up to 6 featured updates, otherwise use 3 most recent updates
-        updates = BlogPost.objects.live().featured()[:6]
+        updates = BlogPost.objects.live().featured().recent()[:6]
         if not updates.exists():
             updates = BlogPost.objects.live().recent()[:3]
         context['updates'] = updates

--- a/cdhweb/people/wagtail_hooks.py
+++ b/cdhweb/people/wagtail_hooks.py
@@ -34,6 +34,7 @@ class ProfileAdmin(ThumbnailMixin, ModelAdmin):
     list_filter = ("person__pu_status", "person__cdh_staff")
     list_per_page = 25
     search_fields = ("title", "body")
+    ordering = ("title",)
     thumb_image_field_name = "image"
     exclude_from_explorer = True
 

--- a/cdhweb/projects/wagtail_hooks.py
+++ b/cdhweb/projects/wagtail_hooks.py
@@ -19,6 +19,7 @@ class ProjectAdmin(ThumbnailMixin, ModelAdmin):
     exclude_from_explorer = True
     thumb_image_field_name = "thumbnail"
     thumb_col_header_text = "thumbnail"
+    ordering = ("title",)
 
 
 class MembershipAdmin(ModelAdmin):


### PR DESCRIPTION
- Add ordering for homepage featured posts (#318)
- Remove Event Meta ordering
- Add wagtail admin ordering for Project, Profile, BlogPost, and Event
