### PR TITLE
Port custom embed finder from mep-django codebase

### DIFF
--- a/cdhweb/pages/embed_finders.py
+++ b/cdhweb/pages/embed_finders.py
@@ -1,0 +1,78 @@
+'''
+Custom :class:`~wagtail.embeds.finders.base.EmbedFinder` implementations
+for embedding content in wagtail pages.
+'''
+
+from json import JSONDecodeError
+from urllib.parse import urljoin
+
+from bs4 import BeautifulSoup
+import requests
+from wagtail.embeds.finders.base import EmbedFinder
+from wagtail.embeds.exceptions import EmbedException
+
+
+class GlitchHubEmbedFinder(EmbedFinder):
+    '''Custom oembed finder built to embed content from Glitch apps and
+    GitHub pages in wagtail pages.
+
+    To support embedding, the glitch app should include a file named
+    embed.json, available directly under the top level url, with
+    oembed content::
+
+        {
+          "title": "title",
+          "author_name": "author",
+          "provider_name": "Glitch",
+          "type": "rich",
+          "thumbnail_url": "URL to thumbnail image",
+          "width": xx,
+          "height": xx
+        }
+
+    If the request for an embed.json file fails, no content will be embedded.
+
+    Any urls that cannot automatically be made relative by embed code (i.e.
+    data files loaded by javascript code) should use absolute URLs, or they
+    will not resolve when embedded.
+    '''
+
+    def accept(self, url):
+        """
+        Accept a url if it includes `.glitch.me`
+        """
+        # return True if this finder can handle a url; no external requests
+        return any(domain in url for domain in ['.glitch.me', 'github.io', 'localhost'])
+
+    def find_embed(self, url, max_width=None):
+        """
+        Retrieve embed.json and requested url and return content
+        for embedding it on the site.
+        """
+        # NOTE: currently ignores max width
+
+        # implementation assumes that glitch has an embed json file
+        # with appropriate metadata
+        response = requests.get(urljoin(url, 'embed.json'))
+        # if embed info couldn't be loaded, error
+        if response.status_code != requests.codes.ok:
+            raise EmbedException('Failed to load embed.json file')
+        try:
+            embed_info = response.json()
+        except JSONDecodeError:
+            raise EmbedException('Error parsing embed.json file')
+
+        # if embed info request succeeded, then get actual content
+        response = requests.get(url)
+        if response.status_code != requests.codes.ok:
+            raise EmbedException('Failed to load url')
+
+        soup = BeautifulSoup(response.content, 'html.parser')
+        # convert relative links so they are absolute to glitch url
+        for link in soup.find_all(href=True):
+            link['href'] = urljoin(url, link['href'])
+        for source in soup.find_all(src=True):
+            source['src'] = urljoin(url, source['src'])
+
+        embed_info['html'] = soup.prettify()
+        return embed_info

--- a/cdhweb/pages/tests/test_embed_finders.py
+++ b/cdhweb/pages/tests/test_embed_finders.py
@@ -1,0 +1,70 @@
+from json import JSONDecodeError
+from unittest.mock import Mock, patch
+
+import requests
+import pytest
+from wagtail.embeds.exceptions import EmbedException
+
+from cdhweb.pages.embed_finders import GlitchHubEmbedFinder
+
+
+class TestGlitchHubEmbedFinder:
+
+    def test_accept(self):
+        assert GlitchHubEmbedFinder().accept('foobar.glitch.me')
+        assert GlitchHubEmbedFinder().accept('https://princeton-cdh.github.io/app/')
+        assert not GlitchHubEmbedFinder().accept('youtube.com/foo')
+
+    test_html = '''<html>
+    <head>
+        <link rel="stylesheet" type="text/css" href="mystyles.css"/>
+    </head>
+    <body>
+        <script src="myscript.js"></script>
+    </body>
+    </html>
+    '''
+
+    @patch('cdhweb.pages.embed_finders.requests')
+    def test_find_embed(self, mockrequests):
+        # patch in actual request status codes
+        mockrequests.codes = requests.codes
+        glitcher = GlitchHubEmbedFinder()
+
+        # embed response fails
+        mockrequests.get.return_value.status_code = 404
+        with pytest.raises(EmbedException):
+            glitcher.find_embed('http://test.glitch.me')
+        mockrequests.get.assert_called_with('http://test.glitch.me/embed.json')
+
+        # json request succeeeds but main url does not
+        mockrequests.get.side_effect = (Mock(status_code=200),
+                                        Mock(status_code=500))
+        with pytest.raises(EmbedException):
+            glitcher.find_embed('http://test.glitch.me')
+        mockrequests.get.side_effect = None
+
+        # json decode error
+        with pytest.raises(EmbedException):
+            mockrequests.get.return_value.json.side_effect = JSONDecodeError
+            glitcher.find_embed('http://test.glitch.me')
+
+        mockrequests.get.return_value.json.side_effect = None
+
+        mockrequests.get.return_value.status_code = 200
+        mock_embed = {
+            'title': 'test glitch',
+            'author_name': 'me'
+        }
+        mockrequests.get.return_value.json.return_value = mock_embed
+        mockrequests.get.return_value.content = self.test_html
+        embed_info = glitcher.find_embed('http://test.glitch.me')
+        mockrequests.get.assert_called_with('http://test.glitch.me')
+        # embed info from json
+        assert embed_info['title'] == mock_embed['title']
+        assert embed_info['author_name'] == mock_embed['author_name']
+        # html from response content
+        assert embed_info['html'].startswith('<html>')
+        # relative links made absolute
+        assert 'href="http://test.glitch.me/mystyles.css' in embed_info['html']
+        assert 'src="http://test.glitch.me/myscript.js' in embed_info['html']

--- a/cdhweb/settings.py
+++ b/cdhweb/settings.py
@@ -306,6 +306,16 @@ CACHES = {
     }
 }
 
+WAGTAILEMBEDS_FINDERS = [
+    {
+        'class': 'wagtail.embeds.finders.oembed'
+    },
+    {
+        'class': 'cdhweb.pages.embed_finders.GlitchHubEmbedFinder'
+    },
+]
+
+
 #########################
 # OPTIONAL APPLICATIONS #
 #########################


### PR DESCRIPTION
copied glich/github custom embed finder from mep-django

did not copy CSP configuration from mep since we aren't using it here