### PR TITLE
Proof-of-concept page search (#19)

### DIFF
--- a/DEPLOYNOTES.rst
+++ b/DEPLOYNOTES.rst
@@ -1,6 +1,17 @@
 Deploy Notes
 ============
 
+3.3
+---
+
+- After deployment, the Wagtail search index should be populated::
+
+    python manage.py update_index
+
+  This command only needs to be run once, since signals will take care of any
+  indexing after the initial run.
+
+
 3.0.2
 -----
 

--- a/cdhweb/blog/models.py
+++ b/cdhweb/blog/models.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import User
 from django.db import models
 from django.urls import reverse
 from django.utils.dateformat import format
@@ -7,16 +6,15 @@ from django.utils.translation import ugettext_lazy as _
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
-from taggit.managers import TaggableManager
 from taggit.models import TaggedItemBase
 from wagtail.admin.edit_handlers import (FieldPanel, FieldRowPanel,
                                          InlinePanel, MultiFieldPanel,
                                          StreamFieldPanel)
 from wagtail.core.models import Orderable, Page, PageManager, PageQuerySet
 from wagtail.images.edit_handlers import ImageChooserPanel
+from wagtail.search import index
 
-from cdhweb.pages.models import (BasePage, LinkPage,
-                                 PagePreviewDescriptionMixin)
+from cdhweb.pages.models import BasePage, LinkPage, PagePreviewDescriptionMixin
 from cdhweb.people.models import Person
 
 
@@ -84,6 +82,9 @@ class BlogPost(BasePage, ClusterableModel, PagePreviewDescriptionMixin):
     promote_panels = Page.promote_panels + [
         FieldPanel("tags")
     ]
+
+    # index description in addition to body content
+    search_fields = BasePage.search_fields + [index.SearchField('description')]
 
     # custom manager/queryset logic
     objects = BlogPostManager()

--- a/cdhweb/pages/models.py
+++ b/cdhweb/pages/models.py
@@ -200,6 +200,9 @@ class ContentPage(BasePage, PagePreviewDescriptionMixin):
         StreamFieldPanel("attachments")
     ]
 
+    # index description in addition to body content
+    search_fields = BasePage.search_fields + [index.SearchField('description')]
+    
     parent_page_types = ['HomePage', 'LandingPage', 'ContentPage']
     subpage_types = ['ContentPage']
 

--- a/cdhweb/pages/templates/cdhpages/page_search.html
+++ b/cdhweb/pages/templates/cdhpages/page_search.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+{% load humanize wagtailcore_tags %}
+
+{% block main %}
+<h1>{{ page_title }}</h1>
+<form action="{% url 'search' %}" method="get">
+    <input type="search" name="q" placeholder="{{ query_placeholder }}" value="{{ active_query }}">
+    <select name="filter">
+        {% for filter in filters %}
+        <option value="{{ filter }}"{% if filter == active_filter %} selected{% endif %}>{{ filter|capfirst }}</option>
+        {% endfor %}
+    </select>
+    <input type="submit" value="Search">
+</form>
+<div>
+    {% if results %}
+    <p>{{ results|length }} result{{ results|pluralize}}</p>
+    <ol>
+    {% for page in results %}
+    <li>{{ page.title }} (<b>{{ page.specific.cached_content_type.name }}</b>) — <i>{{ page.first_published_at|naturalday }}</i></li>
+    {% endfor %}
+    </ol>
+    {% else %}
+    <p>No results found.</p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/cdhweb/pages/views.py
+++ b/cdhweb/pages/views.py
@@ -1,5 +1,12 @@
+from cdhweb.projects.models import Project
+from cdhweb.events.models import Event
+from cdhweb.blog.models import BlogPost
+from cdhweb.people.models import Profile
 from django.utils.cache import get_conditional_response
+from django.views.generic import ListView
 from django.views.generic.base import View
+from wagtail.core.models import Page
+from wagtail.search.utils import parse_query_string
 
 
 class LastModifiedMixin(View):
@@ -49,3 +56,46 @@ class LastModifiedListMixin(LastModifiedMixin):
             return getattr(
                 queryset.order_by(self.lastmodified_attr).reverse().first(),
                 self.lastmodified_attr)
+
+
+class PagesSearchView(ListView):
+    """Search across all pages."""
+
+    model = Page
+    context_object_name = "results"
+    page_title = "Search"
+    query_placeholder = "Search pages"
+    template_name = "cdhpages/page_search.html"
+    filter_models = {
+        "everything": Page,
+        "people": Profile,
+        "updates": BlogPost,
+        "projects": Project,
+        "events": Event,
+    }
+
+    def get_queryset(self):
+        # choose the model to search across; Page for everything
+        filter = self.request.GET.get("filter", "everything")
+        model = self.filter_models[filter]
+
+        # get keyword query; support filters & phrase matching with double quotes
+        # see https://docs.wagtail.io/en/stable/topics/search/searching.html#query-string-parsing
+        q = self.request.GET.get("q", "")
+        _filters, query = parse_query_string(q)
+
+        # execute search against specified model; exclude unpublished pages.
+        # results sorted by relevance by default; to override sort the QS first
+        # and then pass order_by_relevance=false to .search()
+        return model.objects.live().search(query)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update({
+            "page_title": self.page_title,
+            "active_query": self.request.GET.get("q", ""),
+            "filters": self.filter_models.keys(),
+            "active_filter": self.request.GET.get("filter", "everything"),
+            "query_placeholder": self.query_placeholder,
+        })
+        return context

--- a/cdhweb/settings.py
+++ b/cdhweb/settings.py
@@ -35,11 +35,30 @@ TAGGIT_CASE_INSENSITIVE = True
 # https://docs.wagtail.io/en/latest/reference/settings.html#usage-for-images-documents-and-snippets
 WAGTAIL_USAGE_COUNT_ENABLED = True
 
+# Use Wagtail's postgresql search backend.
+# https://docs.wagtail.io/en/latest/reference/contrib/postgres_search.html
+WAGTAILSEARCH_BACKENDS = {
+    "default": {
+        "BACKEND": "wagtail.contrib.postgres_search.backend",
+        "SEARCH_CONFIG": "english",
+    },
+}
+
 # enable feature detection in images
 WAGTAILIMAGES_FEATURE_DETECTION_ENABLED = True
 
 # custom document model
 WAGTAILDOCS_DOCUMENT_MODEL = "cdhpages.LocalAttachment"
+
+# custom embed finders
+WAGTAILEMBEDS_FINDERS = [
+    {
+        'class': 'wagtail.embeds.finders.oembed'
+    },
+    {
+        'class': 'cdhweb.pages.embed_finders.GlitchHubEmbedFinder'
+    },
+]
 
 
 ########################
@@ -246,6 +265,7 @@ INSTALLED_APPS = [
     'wagtail.search',
     'wagtail.admin',
     'wagtail.contrib.modeladmin',
+    'wagtail.contrib.postgres_search',
     'wagtail.core',
     'wagtailmenus',
     'modelcluster',

--- a/cdhweb/urls.py
+++ b/cdhweb/urls.py
@@ -8,12 +8,14 @@ from django.views.generic.base import RedirectView, TemplateView
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.contrib.sitemaps import views as sitemap_views, Sitemap
 from wagtail.core import urls as wagtail_urls
+from wagtail.core.models import Page
 from wagtail.documents import urls as wagtaildocs_urls
 
 from cdhweb.blog.sitemaps import BlogListSitemap
 from cdhweb.people.sitemaps import PeopleListSitemap
 from cdhweb.projects.sitemaps import ProjectListSitemap
 from cdhweb.events.sitemaps import EventListSitemap
+from cdhweb.pages.views import PagesSearchView
 
 
 admin.autodiscover()
@@ -48,6 +50,9 @@ urlpatterns = [
     path("updates/", include("cdhweb.blog.urls", namespace='blog')),
     path("events/", include("cdhweb.events.urls", namespace='event')),
     path("projects/", include("cdhweb.projects.urls", namespace='projects')),
+
+    # search
+    path("search/", PagesSearchView.as_view(), name="search"),
 
     # CAS login urls
     path("accounts/", include('pucas.cas_urls')),


### PR DESCRIPTION
Keeping this as a draft since it's a proof-of-concept implementation/experiment.

Overall, this was very simple to set up. We're using Wagtail's postgres search backend, which is enabled by adding a module to `installed_apps` and setting one setting in `settings.py`. Page content is already setup to be indexed because we defined `search_fields` on our abstract `BasePage` model (which every page type inherits from) to include the `body` field, which is used everywhere for main content. For the two pages with descriptions (`ContentPage` and `BlogPost`), I added their `description` field to `search_fields` as well. The index can be populated on-demand anytime with `python manage.py update_index`, but generally only needs to be run once since signals are automatically set up by wagtail to reindex when page content changes. The only downside to this backend is that it doesn't support partial matching, which you can see if you make a typo. I think this is a small price to pay, though.

I created a very basic view and template that you can view at `/search` with a keyword search and a select box to filter to different types of content. The filtering is done at the database level by selecting a different initial queryset based on the model, and then calling wagtail's search function to apply the keyword query to that queryset. We get a nice bit of free help from wagtail's `parse_query_string`, which automatically converts queries like `foo bar "baz quux" published:yes` into a phrase query for `baz quux`, an ANDed keyword query for `foo AND bar`, and a `filters` dict mapping `published` to `yes`. Not doing anything with the filters yet, but plenty of room to imagine stuff we could do (pub date, etc.) by setting them in the model's `filter_fields`.

There's a wealth of information in the [Wagtail docs on searching](https://docs.wagtail.io/en/stable/topics/search/searching.html), including more info about complex queries, filters, boosting, etc. Note that Wagtail _does_ support searching arbitrary content/django models, but you still need to base that query off of something (i.e. call it on a single queryset). For now, I think it's fine to have the search only operate on `Page` subtypes — that covers all content we can actually link to from a search result, and automatically includes things like landing pages and list pages because they're still `Page` subtypes. I'm not sure what it would look like to search across people or grants, since their search results couldn't really link to anywhere.