### PR TITLE
Implement automatic redirects on slug change (#354)

### DIFF
--- a/cdhweb/pages/tests/test_hooks.py
+++ b/cdhweb/pages/tests/test_hooks.py
@@ -1,0 +1,20 @@
+from django.urls import reverse
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.core import hooks
+
+
+class TestHooks:
+    def test_create_redirect_on_slug_change(db, rf, content_page):
+        """redirect should automatically be created on slug change"""
+        assert Redirect.objects.count() == 0
+        # get the registered hook so we can call it manually to simulate edit
+        hook_fn = hooks.get_hooks("before_edit_page")[0]
+        request = rf.post(
+            reverse("wagtailadmin_pages:edit", args=(content_page.id,)),
+            {"slug": "new-slug"},  # fake changing the slug
+        )
+        hook_fn(request=request, page=content_page)
+        # should redirect old slug to current version of page
+        assert Redirect.objects.filter(
+            old_path="/landing/content", redirect_page=content_page
+        ).exists()

--- a/cdhweb/pages/tests/test_hooks.py
+++ b/cdhweb/pages/tests/test_hooks.py
@@ -14,7 +14,7 @@ class TestHooks:
             reverse("wagtailadmin_pages:edit", args=(content_page.pk,)),
             {
                 "title": content_page.title,
-                "slug": "new-title",    # change slug
+                "slug": "new-slug",  # change slug
                 "body-count": "1",
                 "body-0-deleted": "",
                 "body-0-order": "0",
@@ -23,6 +23,26 @@ class TestHooks:
                 "attachments-count": "0",
                 "action-publish": "Publish",
             },
+        )
+        # Redirect should be created pointing from old path to current page
+        assert Redirect.objects.filter(
+            old_path=old_path, redirect_page=content_page
+        ).exists()
+
+    def test_create_redirect_on_move_page(db, admin_client, content_page, homepage):
+        """redirect should automatically be created on page move"""
+        assert Redirect.objects.count() == 0
+        # Content page starts out underneath a landing page; we move it to
+        # live underneath the homepage instead: /landing/content -> /content
+        old_path = content_page.url[:-1]
+        admin_client.post(
+            reverse(
+                "wagtailadmin_pages:move_confirm",
+                kwargs={
+                    "page_to_move_id": content_page.id,
+                    "destination_id": homepage.id,
+                },
+            ),
         )
         # Redirect should be created pointing from old path to current page
         assert Redirect.objects.filter(

--- a/cdhweb/pages/tests/test_hooks.py
+++ b/cdhweb/pages/tests/test_hooks.py
@@ -1,20 +1,30 @@
 from django.urls import reverse
 from wagtail.contrib.redirects.models import Redirect
-from wagtail.core import hooks
 
 
 class TestHooks:
-    def test_create_redirect_on_slug_change(db, rf, content_page):
+    def test_create_redirect_on_slug_change(db, admin_client, content_page):
         """redirect should automatically be created on slug change"""
         assert Redirect.objects.count() == 0
-        # get the registered hook so we can call it manually to simulate edit
-        hook_fn = hooks.get_hooks("before_edit_page")[0]
-        request = rf.post(
-            reverse("wagtailadmin_pages:edit", args=(content_page.id,)),
-            {"slug": "new-slug"},  # fake changing the slug
+        old_path = content_page.url[:-1]
+        # Change the page's slug by making a POST request; note that we have to
+        # fake all the relevant data from the page's edit form. See also:
+        # https://github.com/wagtail/wagtail/blob/de9588590bbabffbbe30e8830d34b59d8da6512e/wagtail/admin/tests/pages/test_create_page.py#L941-L970
+        admin_client.post(
+            reverse("wagtailadmin_pages:edit", args=(content_page.pk,)),
+            {
+                "title": content_page.title,
+                "slug": "new-title",    # change slug
+                "body-count": "1",
+                "body-0-deleted": "",
+                "body-0-order": "0",
+                "body-0-type": "text",
+                "body-0-value": content_page.body[0].value,
+                "attachments-count": "0",
+                "action-publish": "Publish",
+            },
         )
-        hook_fn(request=request, page=content_page)
-        # should redirect old slug to current version of page
+        # Redirect should be created pointing from old path to current page
         assert Redirect.objects.filter(
-            old_path="/landing/content", redirect_page=content_page
+            old_path=old_path, redirect_page=content_page
         ).exists()

--- a/cdhweb/pages/wagtail_hooks.py
+++ b/cdhweb/pages/wagtail_hooks.py
@@ -19,6 +19,8 @@ def register_exodus_log_action(actions):
     actions.register_action("cdhweb.exodus", "Exodus", "Migrated from cdhweb v2")
 
 
+# Copied directly from Wagtail Recipe:
+# https://docs.wagtail.io/en/stable/reference/pages/model_recipes.html#have-redirects-created-automatically-when-changing-page-slug
 @hooks.register("before_edit_page")
 def create_redirect_on_slug_change(request, page):
     """Automatically create a redirect when a page slug is changed."""

--- a/cdhweb/pages/wagtail_hooks.py
+++ b/cdhweb/pages/wagtail_hooks.py
@@ -31,3 +31,15 @@ def create_redirect_on_slug_change(request, page):
                 site=page.get_site(),
                 redirect_page=page,
             )
+
+
+# Adapted from Wagtail Recipe; see above
+@hooks.register("before_move_page")
+def create_redirect_on_move_page(request, page, destination):
+    """Automatically create a redirect when a page is moved."""
+    if request.method == "POST":
+        Redirect.objects.create(
+            old_path=page.url[:-1],
+            site=page.get_site(),
+            redirect_page=page,
+        )

--- a/cdhweb/pages/wagtail_hooks.py
+++ b/cdhweb/pages/wagtail_hooks.py
@@ -1,6 +1,6 @@
-from django.utils.html import format_html
 from django.templatetags.static import static
-
+from django.utils.html import format_html
+from wagtail.contrib.redirects.models import Redirect
 from wagtail.core import hooks
 
 
@@ -9,12 +9,23 @@ def global_admin_css():
     """Add wagtail custom admin CSS."""
     return format_html(
         '<link rel="stylesheet" href="{}">',
-        static("wagtailadmin/css/custom.css")
+        static("wagtailadmin/css/custom.css"),
     )
 
 
 @hooks.register("register_log_actions")
 def register_exodus_log_action(actions):
     """Add a custom PageLogEntry action to mark page exodus from Mezzanine."""
-    actions.register_action("cdhweb.exodus", "Exodus",
-                            "Migrated from cdhweb v2")
+    actions.register_action("cdhweb.exodus", "Exodus", "Migrated from cdhweb v2")
+
+
+@hooks.register("before_edit_page")
+def create_redirect_on_slug_change(request, page):
+    """Automatically create a redirect when a page slug is changed."""
+    if request.method == "POST":
+        if page.slug != request.POST["slug"]:
+            Redirect.objects.create(
+                old_path=page.url[:-1],
+                site=page.get_site(),
+                redirect_page=page,
+            )


### PR DESCRIPTION
testing was a little confusing; when using the real test client to submit a POST request to change the slug I was getting errors from django-compressor...not sure if it was a red herring, but there was definitely a 500 error that wasn't surfacing properly. settled for just calling the wagtail hook manually to fake the edit event.