### PR TITLE
Add Media Central oEmbed provider (#305)

### DIFF
--- a/cdhweb/settings.py
+++ b/cdhweb/settings.py
@@ -306,9 +306,26 @@ CACHES = {
     }
 }
 
+# Support embedding content from Princeton's Media Central (Kaltura MediaSpace)
+# See https://knowledge.kaltura.com/help/mediaspace-oembed-integration
+media_central_provider = {
+    "endpoint": "https://mediacentral.princeton.edu/oembed",
+    "urls": (
+        r"^https://mediacentral\.princeton\.edu/id/(?:\w+)\?width=\d+&height=\d+&playerId=\d+$",
+        r"^https://mediacentral\.princeton\.edu/media/[^/]+/(?:\w+)$"
+    )
+}
+
+# These will be tried in order; we put the Media Central one first so that the
+# custom provider will be used. See:
+# https://docs.wagtail.io/en/stable/advanced_topics/embeds.html#customising-the-provider-list
 WAGTAILEMBEDS_FINDERS = [
     {
-        'class': 'wagtail.embeds.finders.oembed'
+        'class': 'wagtail.embeds.finders.oembed',
+        'providers': [media_central_provider],
+    },
+    {
+        'class': 'wagtail.embeds.finders.oembed',
     },
     {
         'class': 'cdhweb.pages.embed_finders.GlitchHubEmbedFinder'


### PR DESCRIPTION
This turned out to be much easier than expected — the [MediaSpace docs](https://knowledge.kaltura.com/help/mediaspace-oembed-integration) actually specify the two valid patterns for oEmbed URLs as well as the correct endpoint, so I didn't even need to write a custom provider (Wagtail's method of supplying the provider config was sufficient). Tested using both URL patterns:
- https://mediacentral.princeton.edu/media/Center%20for%20Digital%20Humanities%20Overview/0_mnz807tm (what you get if you just copy from the URL bar when viewing the video on media central)
- https://mediacentral.princeton.edu/id/0_mnz807tm?width=608&height=402&playerId=25624581 (what you get if you copy from the share/oEmbed tab on that page)

Both work and give the same result.

Also, this appears to fix #273 all on its own: the embed is an HTML5 `<video>` instead of an `<iframe>`, and it respects the container margins! Tested using the FF mobile device emulator but would appreciate confirmation.