### PR TITLE
[CDH-65] Fix project and event exports

### DIFF
--- a/cdhweb/events/wagtail_hooks.py
+++ b/cdhweb/events/wagtail_hooks.py
@@ -1,15 +1,16 @@
 from wagtail_modeladmin.mixins import ThumbnailMixin
-from wagtail_modeladmin.options import (ModelAdmin, ModelAdminGroup,
-                                        modeladmin_register)
+from wagtail_modeladmin.options import ModelAdmin, ModelAdminGroup, modeladmin_register
 
 from cdhweb.events.models import Event, EventType, Location
+
+from django.template.defaultfilters import striptags
 
 
 class EventAdmin(ThumbnailMixin, ModelAdmin):
     model = Event
     menu_icon = "date"
     list_display = (
-    "admin_thumb",
+        "admin_thumb",
         "title",
         "type",
         "speaker_list",
@@ -30,7 +31,7 @@ class EventAdmin(ThumbnailMixin, ModelAdmin):
         "attendance",
         "join_url",
         "content",
-        "tags",
+        "tags_",
         "updated",
     )
     export_filename = "cdhweb-events"
@@ -48,6 +49,18 @@ class EventAdmin(ThumbnailMixin, ModelAdmin):
     thumb_col_header_text = "thumbnail"
     ordering = ("-start_time",)
     list_per_page = 25
+
+    def content(self, obj):
+        # Plaintext body, named to match existing field
+        return striptags(obj.body)
+
+    def updated(self, obj):
+        # Alias for last update, named to match existing field
+        return obj.latest_revision_created_at
+
+    def tags_(self, obj):
+        # Transform tags into a spreadsheet-friendly form
+        return ", ".join([t.name for t in obj.tags.all()])
 
 
 class EventTypeAdmin(ModelAdmin):

--- a/cdhweb/projects/wagtail_hooks.py
+++ b/cdhweb/projects/wagtail_hooks.py
@@ -35,6 +35,12 @@ class ProjectAdmin(ThumbnailMixin, ModelAdmin):
     thumb_col_header_text = "thumbnail"
     ordering = ("title",)
 
+    def tags(self, obj):
+        """
+        Generate text tags like we got prior to v4
+        """
+        return obj.display_tags()
+
 
 class MembershipAdmin(ModelAdmin):
     model = Membership

--- a/cdhweb/projects/wagtail_hooks.py
+++ b/cdhweb/projects/wagtail_hooks.py
@@ -1,6 +1,8 @@
 from wagtail_modeladmin.mixins import ThumbnailMixin
 from wagtail_modeladmin.options import ModelAdmin, ModelAdminGroup, modeladmin_register
 
+from django.template.defaultfilters import striptags
+
 from cdhweb.projects.models import (
     GrantType,
     Membership,
@@ -24,8 +26,8 @@ class ProjectAdmin(ThumbnailMixin, ModelAdmin):
         "working_group",
         "cdh_built",
         "tags",
-        "description",
-        "body",
+        "page_summary",
+        "page_content",
         "website_url",
         "last_published_at",
     )
@@ -40,6 +42,15 @@ class ProjectAdmin(ThumbnailMixin, ModelAdmin):
         Generate text tags like we got prior to v4
         """
         return obj.display_tags()
+
+    # Supply plaintext versions of these -- named to
+    # maintain the existing spreadsheet field header (from
+    # verbose_names)
+    def page_summary(self, obj):
+        return striptags(obj.description)
+
+    def page_content(self, obj):
+        return striptags(obj.body)
 
 
 class MembershipAdmin(ModelAdmin):


### PR DESCRIPTION
These exports were causing 500s. 

Needed to:
- Adapt new tags on Projects (this solution mimics previous iteration of the site)
- Strip HTML from summary value on Projects and Events, and Project body
- Process event tags into strings (these were exporting `Event.None` initially for some reason)
- Add an alias from `updated` in the export to `last_revision_created_at` on the Event export