### PR TITLE
[CDH-94] Mobile nav secondary links font size bump

### DIFF
--- a/cdhweb/static_src/global/components/main-nav-mobile.scss
+++ b/cdhweb/static_src/global/components/main-nav-mobile.scss
@@ -167,8 +167,8 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  font-size: px2rem(14);
+  gap: 12px;
+  font-size: px2rem(18);
   margin-block-start: 32px;
 }
 


### PR DESCRIPTION
**Associated Issue(s):**
https://springload-nz.atlassian.net/browse/CDH-94

### Changes in this PR
- Increase font size of secondary links in the opened mobile nav menu. 
- Increase the space between each of these links.

**Before**:
<img width="364" alt="a" src="https://github.com/user-attachments/assets/6d1cfef4-4533-4b87-9300-ef2cdbaf3b9f" />


**After**:
<img width="363" alt="b" src="https://github.com/user-attachments/assets/18c24ec1-0988-4b55-b8ac-92711517a0d4" />

