### PR TITLE
[CDH-83] Mobile safari main nav button text colour

### DIFF
--- a/cdhweb/static_src/global/elements/forms.scss
+++ b/cdhweb/static_src/global/elements/forms.scss
@@ -1,3 +1,8 @@
+button {
+  // mobile safari's UA is a bit different, so we need to explicitly override it
+  color: currentColor;
+}
+
 input {
   &:where([type='text'], [type='email'], [type='password'], [type='number']) {
     font: inherit;


### PR DESCRIPTION
**Associated Issue(s):** 
https://springload-nz.atlassian.net/browse/CDH-83

### Changes in this PR
Fixes the colour of the text in the nav on Safari. This was due to a user agent stylesheet difference in Safari stopping the text colour to be inherited as expected.

