### PR TITLE
[CDH-89] Include future events in profile page "Related events"

### DIFF
--- a/cdhweb/people/models.py
+++ b/cdhweb/people/models.py
@@ -590,15 +590,16 @@ class Profile(BasePage):
         """Add recent BlogPosts by this Person to their Profile."""
         context = super().get_context(request)
         # get 3 most recent published posts with this person as author;
-        # get 3 most recent events with this person as a speaker;
         # get 3 most recent projects with this person as a member;
+        # get 3 most newest events with this person as a speaker;
         # add to context and set open graph metadata
         context.update(
             {
                 "opengraph_type": "profile",
                 "recent_posts": self.person.posts.live().recent()[:3],
-                "recent_events": self.person.events.live().recent()[:3],
                 "recent_projects": self.person.members.live().recent()[:3],
+                # `recent` filter excludes upcoming, but we want future ones listed here
+                "related_events": self.person.events.live().order_by("-start_time")[:3],
             }
         )
         return context

--- a/templates/people/person_page.html
+++ b/templates/people/person_page.html
@@ -26,20 +26,19 @@
                 </div>
             {% endif %}
 
-            {% if recent_events %}
+            {% if related_events %}
                 <div class="block block--tiles">
                     <div class="tiles__title-wrapper">
                         <h2>Related events</h2>
                     </div>
                     <div class="tiles__list">
-                        {% for event in recent_events %}
+                        {% for event in related_events %}
                             {% include 'cdhpages/blocks/tile.html' with internal_page=event tile_type='internal_page_tile' has_component_title=True %}
                         {% endfor %}
                     </div>
                 </div>
             {% endif %}
 
-            {# TODO - when blog page exists #}
             {% if recent_posts %}
                 <div class="block block--tiles">
                     <div class="tiles__title-wrapper">


### PR DESCRIPTION
**Associated Issue(s):** CDH-89

### Changes in this PR

Move the `related_events` segment on `Profile` pages away from using `Events.recent()` to building an explicit queryset that includes future events.

Note that these are currently sorted by `start_date` only, so if someone has 3+ future events, they will end up with no past events listed