### PR TITLE
[CDH-84] Blog tiles, show authors instead of summary

### DIFF
--- a/templates/cdhpages/blocks/tile.html
+++ b/templates/cdhpages/blocks/tile.html
@@ -21,7 +21,14 @@
 
                 {% if internal_page.specific.page_type == 'BlogPost' %}
                     <p>{{ internal_page.specific.first_published_at|date:"j F Y" }}</p>
-                    {{ internal_page.specific.short_description|default:internal_page.specific.description|richtext }}
+                    {# Summary/description is replaced by authors for blog tiles #}
+                    {% if internal_page.specific.authors.all %}
+                        <p>
+                            {% for author in internal_page.specific.authors.all %}
+                                {{ author.person }}{% if not forloop.last %}, {% endif %}
+                            {% endfor %}
+                        </p>
+                    {% endif %}
 
                 {% elif internal_page.specific.page_type != 'Profile' and internal_page.specific.page_type != 'Event' %}
                     {{ internal_page.specific.short_description|default:internal_page.specific.description|richtext }}


### PR DESCRIPTION
**Associated Issue(s):** #
https://springload-nz.atlassian.net/browse/CDH-84

### Changes in this PR
For blog tiles, hide the page summary and instead show authors, (oxford) comma-separated. E.g.
- Jo Bloggs
- Jo Bloggs, Geoff Lasers
- Jo Bloggs, Geoff Lasers, Imhotep McGee

<img width="997" alt="Screenshot 2025-05-23 at 9 31 56 AM" src="https://github.com/user-attachments/assets/f809d8c0-5b0c-46bb-aaf6-26c1b31f2487" />
