### PR TITLE
Sass import overhaul

### DIFF
--- a/cdhweb/static_src/global/components/accordion.scss
+++ b/cdhweb/static_src/global/components/accordion.scss
@@ -1,3 +1,5 @@
+@use '../functions/fn';
+
 .sk-accordion {
   :where(details) {
     margin: 0;
@@ -27,7 +29,7 @@
   :where(summary) {
     cursor: pointer;
     padding-block: 16px;
-    font-size: px2rem(20);
+    font-size: fn.rem(20);
     font-weight: 700;
 
     display: flex;

--- a/cdhweb/static_src/global/components/blog-hero.scss
+++ b/cdhweb/static_src/global/components/blog-hero.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 /* 
 Blog hero. Similar to standard hero. Key differences:
 - image ratio (TODO – maybe?)
@@ -21,27 +24,27 @@ Blog hero. Similar to standard hero. Key differences:
     't t t t t t t t t t t t'
     'd d d d d d d d d d d d';
 
-  @include sm {
+  @include mx.sm {
     margin-block-end: 120px;
   }
 
-  @include md {
+  @include mx.md {
     --title-top-space: 32px;
     grid-template-areas:
       't t t t t t t t t t t t'
       '. d d d d d d d d d d d';
   }
-  @include lg {
+  @include mx.lg {
     --title-top-space: 64px;
 
     grid-template-areas:
       '. t t t t t t t t t t .'
       '. . d d d d d d d d d .';
   }
-  @include xl {
+  @include mx.xl {
     --title-top-space: 104px;
   }
-  @include xxl {
+  @include mx.xxl {
     --title-top-space: 160px;
     grid-template-areas:
       '. t t t t t t t t t . .'
@@ -55,7 +58,7 @@ Blog hero. Similar to standard hero. Key differences:
       't t t t t t t t t t t t'
       'd d d d d d d d d d d d';
 
-    @include lg {
+    @include mx.lg {
       grid-template-areas:
         '. t t t t t i i i i i i'
         '. . d d d d i i i i i i';
@@ -79,8 +82,8 @@ Blog hero. Similar to standard hero. Key differences:
     flex-direction: column;
     gap: 8px;
 
-    @include lg {
-      font-size: px2rem(20);
+    @include mx.lg {
+      font-size: fn.rem(20);
     }
   }
   :where(li) {
@@ -89,7 +92,7 @@ Blog hero. Similar to standard hero. Key differences:
   :where(.tag-list) {
     margin-block-start: 24px;
 
-    @include xl {
+    @include mx.xl {
       margin-block-start: 40px;
     }
   }
@@ -98,21 +101,21 @@ Blog hero. Similar to standard hero. Key differences:
 .blog-hero__date {
   font-weight: bold;
   margin: 16px 0 0;
-  font-size: px2rem(16);
+  font-size: fn.rem(16);
 
-  @include xl {
-    font-size: px2rem(18);
+  @include mx.xl {
+    font-size: fn.rem(18);
   }
 }
 
 .blog-hero__authors {
-  font-size: px2rem(16);
+  font-size: fn.rem(16);
 
-  @include lg {
-    font-size: px2rem(18);
+  @include mx.lg {
+    font-size: fn.rem(18);
   }
-  @include xl {
-    font-size: px2rem(20);
+  @include mx.xl {
+    font-size: fn.rem(20);
   }
 
   :where(ul) {
@@ -125,14 +128,14 @@ Blog hero. Similar to standard hero. Key differences:
 .blog-hero__description {
   grid-area: d;
   margin-block-start: 32px;
-  font-size: px2rem(20);
+  font-size: fn.rem(20);
 
-  @include lg {
+  @include mx.lg {
     margin-block-start: 40px;
   }
-  @include xl {
+  @include mx.xl {
     margin-block-start: 48px;
-    font-size: px2rem(24);
+    font-size: fn.rem(24);
   }
 }
 
@@ -140,16 +143,16 @@ Blog hero. Similar to standard hero. Key differences:
   grid-area: i;
 
   :where(img) {
-    @include break-grid;
+    @include mx.break-grid;
 
-    @include sm {
-      @include undo-break-grid;
+    @include mx.sm {
+      @include mx.undo-break-grid;
     }
-    @include lg {
-      @include break-grid-right;
+    @include mx.lg {
+      @include mx.break-grid-right;
     }
-    @include xxxl {
-      @include undo-break-grid;
+    @include mx.xxxl {
+      @include mx.undo-break-grid;
     }
   }
 }

--- a/cdhweb/static_src/global/components/breadcrumbs.scss
+++ b/cdhweb/static_src/global/components/breadcrumbs.scss
@@ -1,17 +1,20 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .breadcrumbs {
-  font-size: px2rem(14);
+  font-size: fn.rem(14);
   line-height: 1.62;
   margin-block: 20px 12px;
   grid-column: 1 / -1;
 
-  @include sm {
+  @include mx.sm {
     margin-block: 40px 24px;
   }
-  @include md {
+  @include mx.md {
     grid-column: 2 / -1;
     margin-block: 48px 16px;
   }
-  @include lg {
+  @include mx.lg {
     grid-column: 3 / -1;
   }
 }
@@ -27,10 +30,10 @@
 .breadcrumbs__item {
   display: none;
   align-items: center;
-  gap: px2rem(9); // space before '/'
+  gap: fn.rem(9); // space before '/'
   margin: 0;
 
-  @include sm {
+  @include mx.sm {
     display: flex;
   }
 }
@@ -46,7 +49,7 @@
 .breadcrumbs__item--current-page {
   display: none;
 
-  @include sm {
+  @include mx.sm {
     display: flex;
   }
 }
@@ -56,24 +59,24 @@
 
 .breadcrumbs__link--parent {
   display: flex;
-  gap: px2rem(8);
+  gap: fn.rem(8);
 }
 
 // mobile-only back icon:
 .breadcrumbs__back-icon {
-  width: px2rem(15);
+  width: fn.rem(15);
   aspect-ratio: 11 / 16;
 
-  @include sm {
+  @include mx.sm {
     display: none;
   }
 }
 
 .breadcrumbs__separator {
   display: none;
-  margin-right: px2rem(9); // space after '/'
+  margin-right: fn.rem(9); // space after '/'
 
-  @include sm {
+  @include mx.sm {
     display: inline-block;
   }
 }

--- a/cdhweb/static_src/global/components/btn.scss
+++ b/cdhweb/static_src/global/components/btn.scss
@@ -1,14 +1,17 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .sk-btn {
-  @include btn;
+  @include mx.btn;
 }
 .sk-btn--primary {
-  @include btn-primary;
+  @include mx.btn-primary;
 }
 .sk-btn--secondary {
-  @include btn-secondary;
+  @include mx.btn-secondary;
 }
 .sk-btn--link-style {
-  @include btn-link-style;
+  @include mx.btn-link-style;
 }
 
 .sk-btn-group {
@@ -17,7 +20,7 @@
   gap: 13px 16px;
   align-items: center;
 
-  @include sm {
+  @include mx.sm {
     flex-direction: row;
     flex-wrap: wrap;
   }
@@ -29,7 +32,7 @@
   // a "primary" style is if there are two buttons.
   &:not(:has(.sk-btn--secondary)) {
     .sk-btn--primary {
-      @include btn-secondary;
+      @include mx.btn-secondary;
     }
   }
 }

--- a/cdhweb/static_src/global/components/cta.scss
+++ b/cdhweb/static_src/global/components/cta.scss
@@ -1,9 +1,12 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .cta {
   border: 1px solid var(--color-brand-100);
   background-color: var(--color-brand-5);
   padding: 24px;
 
-  @include sm {
+  @include mx.sm {
     padding: 40px;
   }
 

--- a/cdhweb/static_src/global/components/download.scss
+++ b/cdhweb/static_src/global/components/download.scss
@@ -1,20 +1,23 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .download {
   border: 1px solid var(--color-brand-100);
   background-color: var(--color-brand-5);
-  font-size: px2rem(18);
+  font-size: fn.rem(18);
   padding: 24px;
 
-  @include sm {
+  @include mx.sm {
     padding: 32px;
   }
 
   :where(h2) {
     font-weight: 900;
-    font-size: px2rem(20);
+    font-size: fn.rem(20);
     margin-block-end: 8px;
 
-    @include sm {
-      font-size: px2rem(24);
+    @include mx.sm {
+      font-size: fn.rem(24);
     }
   }
 
@@ -45,10 +48,10 @@
     aspect-ratio: 18 / 25;
     width: 18px;
     position: relative;
-    top: px2rem(4);
+    top: fn.rem(4);
   }
 }
 
 .download__file-title {
-  @include link-style;
+  @include mx.link-style;
 }

--- a/cdhweb/static_src/global/components/event-hero.scss
+++ b/cdhweb/static_src/global/components/event-hero.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 /* 
 Event hero. Similar to standard hero. Key differences:
 - image ratio (TODO – maybe?)
@@ -17,22 +20,22 @@ Event hero. Similar to standard hero. Key differences:
   // Layout if there is _no_ image:
   grid-template-areas: 't t t t t t t t t t t t';
 
-  @include sm {
+  @include mx.sm {
     margin-block-end: 120px;
   }
 
-  @include md {
+  @include mx.md {
     --title-top-space: 64px;
   }
-  @include lg {
+  @include mx.lg {
     --title-top-space: 80px;
 
     grid-template-areas: '. t t t t t t t t t t .';
   }
-  @include xl {
+  @include mx.xl {
     --title-top-space: 104px;
   }
-  @include xxl {
+  @include mx.xxl {
     --title-top-space: 160px;
     grid-template-areas: '. t t t t t t t t t . .';
   }
@@ -43,10 +46,10 @@ Event hero. Similar to standard hero. Key differences:
       'i i i i i i i i i i i i'
       't t t t t t t t t t t t';
 
-    @include md {
+    @include mx.md {
       grid-template-areas: 't t t t t t i i i i i i';
     }
-    @include lg {
+    @include mx.lg {
       grid-template-areas: '. t t t t t i i i i i i';
     }
   }
@@ -54,7 +57,7 @@ Event hero. Similar to standard hero. Key differences:
 
 .event-hero__text {
   grid-area: t;
-  font-size: px2rem(16);
+  font-size: fn.rem(16);
   line-height: 1.125;
 
   :where(h1) {
@@ -69,8 +72,8 @@ Event hero. Similar to standard hero. Key differences:
     flex-direction: column;
     gap: 8px;
 
-    @include lg {
-      font-size: px2rem(20);
+    @include mx.lg {
+      font-size: fn.rem(20);
     }
   }
   :where(li) {
@@ -79,7 +82,7 @@ Event hero. Similar to standard hero. Key differences:
   :where(.tag-list) {
     margin-block-start: 24px;
 
-    @include xl {
+    @include mx.xl {
       margin-block-start: 40px;
     }
   }
@@ -92,7 +95,7 @@ Event hero. Similar to standard hero. Key differences:
 
 .event-hero__add-to-calendar {
   margin: 4px 0 16px;
-  font-size: px2rem(14);
+  font-size: fn.rem(14);
 }
 
 .event-hero__location {
@@ -104,17 +107,17 @@ Event hero. Similar to standard hero. Key differences:
   grid-area: i;
 
   :where(img) {
-    @include break-grid;
+    @include mx.break-grid;
 
-    @include sm {
-      @include undo-break-grid;
+    @include mx.sm {
+      @include mx.undo-break-grid;
     }
-    @include md {
-      @include break-grid-right;
+    @include mx.md {
+      @include mx.break-grid-right;
     }
 
-    @include xxxl {
-      @include undo-break-grid;
+    @include mx.xxxl {
+      @include mx.undo-break-grid;
     }
   }
 }

--- a/cdhweb/static_src/global/components/feature.scss
+++ b/cdhweb/static_src/global/components/feature.scss
@@ -1,44 +1,47 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .feature {
   --three-dee-side-size: 18px;
 
-  font-size: px2rem(20);
+  font-size: fn.rem(20);
   display: grid;
 
   position: relative;
-  @include three-dee-box;
+  @include mx.three-dee-box;
 
-  @include xl {
+  @include mx.xl {
     --three-dee-side-size: 56px;
     grid-template-columns: repeat(2, 1fr);
-    font-size: px2rem(22);
+    font-size: fn.rem(22);
   }
 }
 
 .feature__text-content {
   padding: 24px 16px;
 
-  @include sm {
+  @include mx.sm {
     padding: 32px;
   }
 
   :where(h2) {
-    font-size: px2rem(24);
+    font-size: fn.rem(24);
     text-wrap: pretty;
 
-    @include sm {
-      font-size: px2rem(32);
+    @include mx.sm {
+      font-size: fn.rem(32);
     }
-    @include xl {
-      font-size: px2rem(36);
+    @include mx.xl {
+      font-size: fn.rem(36);
     }
   }
   :where(.sk-btn-group) {
     margin-block-start: 16px;
 
-    @include sm {
+    @include mx.sm {
       margin-block-start: 24px;
     }
-    @include xl {
+    @include mx.xl {
       margin-block-start: 40px;
     }
   }
@@ -47,7 +50,7 @@
 .feature__img {
   order: -1; // on top when stacked
 
-  @include xl {
+  @include mx.xl {
     order: unset;
   }
 
@@ -55,7 +58,7 @@
     object-fit: cover;
     max-height: 350px;
 
-    @include xl {
+    @include mx.xl {
       height: 100%;
       max-height: unset;
     }

--- a/cdhweb/static_src/global/components/footer.scss
+++ b/cdhweb/static_src/global/components/footer.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .footer {
   --color-link-underline: var(--color-brand-110);
 
@@ -10,7 +13,7 @@
     var(--color-brand-100) 224px
   );
 
-  @include md {
+  @include mx.md {
     margin-block-start: 184px;
     padding-block-start: 128px;
 
@@ -20,10 +23,10 @@
       }
     }
   }
-  @include lg {
+  @include mx.lg {
     margin-block-start: 208px;
   }
-  @include xl {
+  @include mx.xl {
     padding-block-start: 176px;
   }
 }
@@ -39,17 +42,17 @@
   gap: 24px;
   margin-block-end: 32px;
 
-  @include md {
+  @include mx.md {
     grid-template-areas: 'l l l s s s s s s s s s';
     margin-block-end: 56px;
   }
-  @include lg {
+  @include mx.lg {
     grid-template-areas: 'l l l s s s s s s s s .';
   }
-  @include xl {
+  @include mx.xl {
     grid-template-areas: 'l l s s s s s s s . . .';
   }
-  @include xxl {
+  @include mx.xxl {
     grid-template-areas: 'l l s s s s s s . . . .';
   }
 }
@@ -61,10 +64,10 @@
     max-width: 120px;
     aspect-ratio: 160 / 120;
 
-    @include md {
+    @include mx.md {
       max-width: 136px;
     }
-    @include xl {
+    @include mx.xl {
       max-width: 160px;
     }
   }
@@ -77,7 +80,7 @@
 .footer__search-heading {
   margin-block-end: 16px;
 
-  @include md {
+  @include mx.md {
     margin-block-end: 20px;
   }
 }
@@ -99,20 +102,20 @@
     'p p p p p p p p p p p p';
 
   // Default, overridden for some elements
-  font-size: px2rem(16);
+  font-size: fn.rem(16);
 
-  @include md {
+  @include mx.md {
     grid-template-areas:
       'h h h h h h h h h h h h'
       'c c c c c . u u u u u .'
       'a a a a a a . . . . . .'
       'p p p p . . . . . . . .';
-    font-size: px2rem(18);
+    font-size: fn.rem(18);
   }
-  @include lg {
+  @include mx.lg {
     --v-link-space: 16px;
   }
-  @include xl {
+  @include mx.xl {
     grid-template-areas:
       'h h h h h h h h h h h h'
       'c c c c a a a a u u u u'
@@ -128,14 +131,14 @@
   grid-area: h;
   margin-block-end: 16px;
 
-  @include md {
+  @include mx.md {
     margin-block-end: 24px;
   }
 }
 
 // Shared font styles only
 .footer__heading-text {
-  font-size: px2rem(20);
+  font-size: fn.rem(20);
   font-weight: 900;
 }
 
@@ -162,7 +165,7 @@
   gap: 24px;
   margin-block-start: 40px;
 
-  @include xl {
+  @include mx.xl {
     margin-block-start: 56px;
   }
 
@@ -173,10 +176,10 @@
 }
 
 .footer__address {
-  font-size: px2rem(14);
+  font-size: fn.rem(14);
   margin-block-start: 32px;
 
-  @include xl {
+  @include mx.xl {
     margin-block-start: 0;
   }
 
@@ -189,16 +192,16 @@
 .footer__newsletter {
   margin-block-start: 24px;
 
-  @include md {
+  @include mx.md {
     margin-block-start: 24px;
   }
 
   :where(h2) {
-    font-size: px2rem(15);
+    font-size: fn.rem(15);
     margin-block-end: 14px;
 
-    @include md {
-      font-size: px2rem(17);
+    @include mx.md {
+      font-size: fn.rem(17);
       margin-block-end: 20px;
     }
 
@@ -216,7 +219,7 @@
   grid-area: u;
   margin-block-start: 32px;
 
-  @include md {
+  @include mx.md {
     margin-block-start: 0;
   }
 }
@@ -237,7 +240,7 @@
   padding-block: 30px;
   margin-block-start: 24px;
 
-  @include md {
+  @include mx.md {
     margin-block-start: 80px;
   }
 }
@@ -247,9 +250,9 @@
   display: flex;
   flex-direction: column;
   gap: 24px;
-  font-size: px2rem(14);
+  font-size: fn.rem(14);
 
-  @include lg {
+  @include mx.lg {
     flex-direction: row;
     justify-content: space-between;
   }
@@ -261,7 +264,7 @@
     flex-direction: column;
     gap: 16px;
 
-    @include lg {
+    @include mx.lg {
       flex-direction: row;
       flex-wrap: wrap;
       column-gap: 72px;
@@ -269,16 +272,17 @@
   }
 }
 
-.footer__copyright, .footer__version {
+.footer__copyright,
+.footer__version {
   flex-shrink: 0;
   align-self: start;
-  @include lg {
-    align-self: end;      
+  @include mx.lg {
+    align-self: end;
     text-align: right;
   }
 }
 
-.footer__copyright  {
+.footer__copyright {
   flex-grow: 1;
 }
 
@@ -286,5 +290,3 @@
   font-weight: normal;
   text-decoration: none;
 }
-
-

--- a/cdhweb/static_src/global/components/forms.scss
+++ b/cdhweb/static_src/global/components/forms.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 // Input with joined-up inline submit button.
 // Used for search and email signup forms.
 .text-input-and-button-group {
@@ -16,7 +19,7 @@
     border: 1px solid var(--form-control-border-color, var(--color-grey-110));
     border-right: 0;
     border-radius: var(--radius) 0 0 var(--radius);
-    font-size: px2rem(16);
+    font-size: fn.rem(16);
   }
   :where(input[type='submit']) {
     cursor: pointer;
@@ -26,7 +29,7 @@
     border: 1px solid var(--form-control-border-color, transparent);
     border-left: 0;
     border-radius: 0 var(--radius) var(--radius) 0;
-    font-size: px2rem(15);
+    font-size: fn.rem(15);
     font-weight: bold;
 
     &:hover {
@@ -38,14 +41,14 @@
 // Custom checkboxes and radios.
 // Shared styles here. radio/checkbox-specific styles afterwards.
 :is(.checkbox, .radio) {
-  --input-size: #{px2rem(20)};
+  --input-size: #{fn.rem(20)};
 
   position: relative;
   display: flex;
   align-items: center;
 
   :where(input) {
-    @include visuallyHidden;
+    @include mx.visuallyHidden;
   }
   :where(label) {
     cursor: pointer;
@@ -103,9 +106,9 @@
       content: '';
       opacity: 0; // only shown when :checked
       position: absolute;
-      left: px2rem(3);
-      top: px2rem(5);
-      width: px2rem(13);
+      left: fn.rem(3);
+      top: fn.rem(5);
+      width: fn.rem(13);
       aspect-ratio: 14/10; // from viewbox
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 10'%3E%3Cpath fill='%23fff' d='m12.8 2.5-6.6 6.6a1.2 1.2 0 01-1.7 0l-3.3-3.3a1.2 1.2 0 010-1.7 1.2 1.2 0 011.7 0l2.5 2.6 5.7-5.8a1.2 1.2 0 011.7 0 1.2 1.2 0 010 1.6z' /%3E%3C/svg%3E%0A");
       background-repeat: no-repeat;

--- a/cdhweb/static_src/global/components/home-hero.scss
+++ b/cdhweb/static_src/global/components/home-hero.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 // has `.grid-standard`
 .home-hero {
   --bg-box-border-width: 8px;
@@ -21,18 +24,18 @@
     'i i i i i i i i i i i i'
     '. c c c c c c c c c . .';
 
-  @include sm {
+  @include mx.sm {
     --space-below-box: 80px;
   }
 
-  @include md {
+  @include mx.md {
     --space-below-box: 104px;
 
     grid-template-areas:
       'i i i i i i i i i i i i'
       '. c c c c c c c . . . .';
   }
-  @include lg {
+  @include mx.lg {
     --bg-box-x-pad: 56px;
     --bg-box-y-pad: 40px;
 
@@ -41,13 +44,13 @@
       '. . c c c c c c . . . .';
   }
 
-  @include xl {
+  @include mx.xl {
     grid-template-areas:
       '. i i i i i i i i i i .'
       '. . c c c c c . . . . .';
   }
 
-  @include xxl {
+  @include mx.xxl {
     --space-below-box: 136px;
   }
 }
@@ -64,13 +67,13 @@
 
   :where(h1) {
     margin: 0 0 8px;
-    @include lg {
+    @include mx.lg {
       margin-block-end: 16px;
     }
   }
   :where(p) {
     margin: 0;
-    font-size: px2rem(24);
+    font-size: fn.rem(24);
     line-height: 1.5;
   }
 }
@@ -79,24 +82,23 @@
 // This usage is different to the others because the *text content* is what
 // aligns to the grid, and the 3d box is absolute-positioned around it as a separate element.
 .hero-home__box {
-  position: absolute;
+  @include mx.three-dee-box;
+  & {
+    position: absolute;
+    top: 0;
+    width: calc(100% + var(--bg-box-x-pad) * 2);
+    height: calc(100% + var(--bg-box-y-pad) * 2);
+    transform: translate(
+      calc(-1 * var(--bg-box-x-pad)),
+      calc(-1 * var(--bg-box-y-pad))
+    );
+  }
 
-  @include three-dee-box;
-
-  position: absolute;
-  top: 0;
-  width: calc(100% + var(--bg-box-x-pad) * 2);
-  height: calc(100% + var(--bg-box-y-pad) * 2);
-  transform: translate(
-    calc(-1 * var(--bg-box-x-pad)),
-    calc(-1 * var(--bg-box-y-pad))
-  );
-
-  @include md {
+  @include mx.md {
     --three-dee-side-size: 56px;
   }
 
-  @include xl {
+  @include mx.xl {
     // Same as declaration above. Needed to stop mixin setting it to something else.
     width: calc(100% + var(--bg-box-x-pad) * 2);
   }
@@ -104,16 +106,16 @@
 
 .home-hero__img {
   grid-area: i;
-  @include break-grid;
+  @include mx.break-grid;
 
   object-fit: cover;
   height: 312px;
 
-  @include sm {
+  @include mx.sm {
     height: 498px;
   }
 
-  @include xl {
-    @include undo-break-grid;
+  @include mx.xl {
+    @include mx.undo-break-grid;
   }
 }

--- a/cdhweb/static_src/global/components/image.scss
+++ b/cdhweb/static_src/global/components/image.scss
@@ -1,13 +1,16 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 // .sk-image {
 // }
 
 .sk-image--small {
   :where(img) {
     inline-size: 50%;
-    max-inline-size: px2rem(550);
+    max-inline-size: fn.rem(550);
   }
   :where(figcaption) {
-    @include xl {
+    @include mx.xl {
       inline-size: 50%;
     }
   }
@@ -17,7 +20,7 @@
   :where(img) {
     inline-size: 85%;
 
-    @include md {
+    @include mx.md {
       inline-size: 75%;
     }
   }
@@ -25,10 +28,10 @@
 
 .sk-image--large {
   :where(img) {
-    @include break-grid;
+    @include mx.break-grid;
 
-    @include md {
-      @include undo-break-grid;
+    @include mx.md {
+      @include mx.undo-break-grid;
       inline-size: calc(var(--content-outdent) + 100%);
       margin-inline-start: calc(-1 * var(--content-outdent));
     }
@@ -37,13 +40,13 @@
 
 .sk-image__text-content {
   --color-link-underline: currentColor;
-  font-size: px2rem(14);
+  font-size: fn.rem(14);
 
   // The image block itself is wider, to allow images to be wider than captions
   max-inline-size: var(--reading-max-width);
 
-  @include sm {
-    font-size: px2rem(16);
+  @include mx.sm {
+    font-size: fn.rem(16);
   }
 }
 

--- a/cdhweb/static_src/global/components/jumplinks.scss
+++ b/cdhweb/static_src/global/components/jumplinks.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .sk-jumplinks {
   margin-bottom: var(--streamfield-space-lg);
 }
@@ -5,7 +8,7 @@
 .sk-jumplinks__heading {
   margin-block-end: 24px;
 
-  @include md {
+  @include mx.md {
     margin-left: calc(-1 * var(--content-outdent));
   }
 }
@@ -13,7 +16,7 @@
 .sk-jumplinks__list {
   padding: 0;
   list-style-type: none;
-  font-size: px2rem(18);
+  font-size: fn.rem(18);
 }
 
 .sk-jumplinks__link {

--- a/cdhweb/static_src/global/components/main-nav-desktop.scss
+++ b/cdhweb/static_src/global/components/main-nav-desktop.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .main-nav-desktop {
   --logo-overlap: 24px;
 
@@ -8,10 +11,10 @@
   padding-block-start: 24px;
   color: var(--color-grey-110);
 
-  @include lg {
+  @include mx.lg {
     display: block;
   }
-  @include xl {
+  @include mx.xl {
     --logo-overlap: 28px;
   }
 
@@ -56,7 +59,7 @@
     width: 138px;
     aspect-ratio: 160 / 120;
 
-    @include xl {
+    @include mx.xl {
       width: 160px;
     }
   }
@@ -71,7 +74,7 @@
 
   list-style-type: none;
   padding: 0;
-  font-size: px2rem(14);
+  font-size: fn.rem(14);
 
   display: flex;
   flex-wrap: wrap;
@@ -80,7 +83,7 @@
 }
 
 .main-nav-desktop__cta {
-  font-size: px2rem(14);
+  font-size: fn.rem(14);
   padding: 8px 16px;
 }
 
@@ -95,10 +98,10 @@
   flex-wrap: wrap; // hopefully won't need to, but just in case.
   gap: 32px;
   padding: 0;
-  font-size: px2rem(16);
+  font-size: fn.rem(16);
 
-  @include xxl {
-    font-size: px2rem(18);
+  @include mx.xxl {
+    font-size: fn.rem(18);
   }
 }
 
@@ -178,11 +181,11 @@
 
   :where(h2) {
     margin-block-end: 16px;
-    font-size: px2rem(32);
+    font-size: fn.rem(32);
   }
   :where(p) {
     margin: 0;
-    font-size: px2rem(18);
+    font-size: fn.rem(18);
   }
   :where(.sk-btn) {
     margin-block-start: 24px;
@@ -197,7 +200,7 @@
     text-decoration-thickness: 4px;
   }
 
-  @include xl {
+  @include mx.xl {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 48px;
@@ -214,7 +217,7 @@
   & + & {
     margin-block-start: var(--space-between-links);
 
-    @include xl {
+    @include mx.xl {
       margin-block-start: 0;
     }
   }

--- a/cdhweb/static_src/global/components/main-nav-mobile.scss
+++ b/cdhweb/static_src/global/components/main-nav-mobile.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 // This is the header element that wraps both tme mobile and desktop <nav>s.
 .header {
   border-bottom: 1px solid var(--color-brand-100);
@@ -12,7 +15,7 @@
 }
 
 .main-nav-mobile {
-  @include lg {
+  @include mx.lg {
     display: none;
   }
 }
@@ -57,7 +60,7 @@
 }
 
 .mobile-menu__header-btn-icon {
-  width: px2rem(20);
+  width: fn.rem(20);
   aspect-ratio: 1;
 }
 
@@ -87,10 +90,10 @@
   padding: 20px 0;
   border-bottom: 1px solid transparent;
   font-weight: bold;
-  font-size: px2rem(22);
+  font-size: fn.rem(22);
 
   &[aria-expanded='true'] {
-    @include full-bleed-bg(var(--color-brand-40));
+    @include mx.full-bleed-bg(var(--color-brand-40));
   }
   &:not([aria-expanded='true']) {
     --icon-color: var(--icon-color-dark);
@@ -127,9 +130,9 @@
   --icon-accent-color: var(--color-brand-120);
   background-color: var(--color-brand-100);
   padding-block-end: 32px;
-  font-size: px2rem(16);
+  font-size: fn.rem(16);
 
-  @include full-bleed-bg(var(--color-brand-40));
+  @include mx.full-bleed-bg(var(--color-brand-40));
 }
 
 .mobile-menu__sub-menu-description {
@@ -137,7 +140,7 @@
 }
 
 .mobile-menu__sub-menu-goto-link {
-  font-size: px2rem(14);
+  font-size: fn.rem(14);
 }
 
 .mobile-menu__sub-menu-list {
@@ -154,7 +157,7 @@
   padding-block: 32px 48px;
 
   :where(h2) {
-    font-size: px2rem(17);
+    font-size: fn.rem(17);
     margin-block-end: 20px;
     font-weight: 900;
   }
@@ -168,7 +171,7 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  font-size: px2rem(18);
+  font-size: fn.rem(18);
   margin-block-start: 32px;
 }
 

--- a/cdhweb/static_src/global/components/newsletter.scss
+++ b/cdhweb/static_src/global/components/newsletter.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 /*
 Newsletter streamfield block.
 Note: this uses the same `includes/newsletter_form.html` rendered by in <footer>.
@@ -17,23 +20,23 @@ We don't have a streamfield-specific template for it, but we conditionally add a
   color: var(--color-white);
   padding: 16px;
 
-  @include three-dee-box;
+  @include mx.three-dee-box;
 
-  @include xl {
+  @include mx.xl {
     padding: 24px;
     --three-dee-side-size: 56px;
   }
 
   :where(h2) {
     font-weight: bold;
-    font-size: px2rem(18);
+    font-size: fn.rem(18);
     margin-block-end: 14px;
     display: flex;
     gap: 8px;
     align-items: center;
 
-    @include sm {
-      font-size: px2rem(22);
+    @include mx.sm {
+      font-size: fn.rem(22);
     }
 
     :where(svg) {

--- a/cdhweb/static_src/global/components/note.scss
+++ b/cdhweb/static_src/global/components/note.scss
@@ -1,9 +1,12 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .note {
   background-color: var(--color-brand-5);
   border: 1px solid var(--color-brand-100);
   padding: 16px;
 
-  @include sm {
+  @include mx.sm {
     padding: 32px;
   }
 

--- a/cdhweb/static_src/global/components/pagination.scss
+++ b/cdhweb/static_src/global/components/pagination.scss
@@ -1,9 +1,11 @@
+@use '../functions/fn';
+
 .pagination {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 16px;
-  font-size: px2rem(16);
+  font-size: fn.rem(16);
   margin-block-start: 56px;
   padding-block-start: 40px;
   border-top: 1px solid var(--color-brand-100);

--- a/cdhweb/static_src/global/components/person-hero.scss
+++ b/cdhweb/static_src/global/components/person-hero.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 /* 
 Person hero. Similar to standard hero. Key differences:
 - image ratio (TODO – maybe?)
@@ -18,30 +21,30 @@ Person hero. Similar to standard hero. Key differences:
     'h h h h h h h h h h h h'
     'c c c c c c c c c c c c';
 
-  @include sm {
+  @include mx.sm {
     margin-block-end: 120px;
   }
 
-  @include md {
+  @include mx.md {
     --title-top-space: 64px;
 
     grid-template-areas:
       'h h h h h h h h h h h h'
       '. c c c c c c c c c c c';
   }
-  @include lg {
+  @include mx.lg {
     --title-top-space: 80px;
     grid-template-areas:
       '. h h h h h h h h h h .'
       '. . c c c c c c c c c .';
   }
-  @include xl {
+  @include mx.xl {
     --title-top-space: 104px;
     grid-template-areas:
       '. h h h h h h h h . . .'
       '. . c c c c c c c . . .';
   }
-  @include xxl {
+  @include mx.xxl {
     --title-top-space: 160px;
     grid-template-areas:
       '. h h h h h h h h . . .'
@@ -55,12 +58,12 @@ Person hero. Similar to standard hero. Key differences:
       'h h h h h h h h h h h h'
       'c c c c c c c c c c c c';
 
-    @include md {
+    @include mx.md {
       grid-template-areas:
         'h h h h h h i i i i i i'
         '. c c c c c i i i i i i';
     }
-    @include lg {
+    @include mx.lg {
       grid-template-areas:
         '. h h h h h i i i i i i'
         '. . c c c c i i i i i i';
@@ -82,22 +85,22 @@ Person hero. Similar to standard hero. Key differences:
 
 .person-hero__job {
   margin: 16px 0 0;
-  font-size: px2rem(24);
+  font-size: fn.rem(24);
   line-height: 1.125;
 
-  @include xl {
-    font-size: px2rem(28);
+  @include mx.xl {
+    font-size: fn.rem(28);
   }
 }
 
 .person-hero__education {
   margin-block-start: 16px;
-  font-size: px2rem(15);
+  font-size: fn.rem(15);
 }
 
 .person-hero__contact {
   grid-area: c;
-  font-size: px2rem(14);
+  font-size: fn.rem(14);
   line-height: 1.62;
   margin-block-start: 48px;
 
@@ -105,21 +108,21 @@ Person hero. Similar to standard hero. Key differences:
   flex-direction: column;
   gap: 24px;
 
-  @include sm {
+  @include mx.sm {
     flex-direction: row;
     flex-wrap: wrap;
   }
 
-  @include lg {
+  @include mx.lg {
     margin-block-start: 56px;
   }
-  @include xl {
-    font-size: px2rem(16);
+  @include mx.xl {
+    font-size: fn.rem(16);
   }
 }
 
 .person-hero__contact-links {
-  flex: 1 1 px2rem(210);
+  flex: 1 1 fn.rem(210);
 
   list-style-type: none;
   padding: 0;
@@ -136,7 +139,7 @@ Person hero. Similar to standard hero. Key differences:
 }
 
 .person-hero__icon {
-  width: px2rem(24);
+  width: fn.rem(24);
   flex-shrink: 0;
 }
 .person-hero__icon--email {
@@ -151,16 +154,16 @@ Person hero. Similar to standard hero. Key differences:
 
 .person-hero__img {
   grid-area: i;
-  @include break-grid;
+  @include mx.break-grid;
 
-  @include sm {
-    @include undo-break-grid;
+  @include mx.sm {
+    @include mx.undo-break-grid;
   }
-  @include md {
-    @include break-grid-right;
+  @include mx.md {
+    @include mx.break-grid-right;
   }
 
-  @include xxxl {
-    @include undo-break-grid;
+  @include mx.xxxl {
+    @include mx.undo-break-grid;
   }
 }

--- a/cdhweb/static_src/global/components/project-hero.scss
+++ b/cdhweb/static_src/global/components/project-hero.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 /*
 Similar to standard hero, but with a tag/chip thing that can show above the title,
 and some meta info that can appear below the description (like blog hero).
@@ -18,25 +21,25 @@ and some meta info that can appear below the description (like blog hero).
     't t t t t t t t t t t t'
     'd d d d d d d d d d d d';
 
-  @include sm {
+  @include mx.sm {
     margin-block-end: 120px;
   }
 
-  @include md {
+  @include mx.md {
     --title-top-space: 40px;
 
     grid-template-areas:
       't t t t t t t t t t t t'
       '. d d d d d d d d d d d';
   }
-  @include lg {
+  @include mx.lg {
     --title-top-space: 80px;
 
     grid-template-areas:
       '. t t t t t t t t t t .'
       '. . d d d d d d d d d .';
   }
-  @include xxl {
+  @include mx.xxl {
     grid-template-areas:
       '. t t t t t t t t t . .'
       '. . d d d d d d d d . .';
@@ -49,12 +52,12 @@ and some meta info that can appear below the description (like blog hero).
       't t t t t t t t t t t t'
       'd d d d d d d d d d d d';
 
-    @include md {
+    @include mx.md {
       grid-template-areas:
         't t t t t t i i i i i i'
         '. d d d d d i i i i i i';
     }
-    @include lg {
+    @include mx.lg {
       grid-template-areas:
         '. t t t t t i i i i i i'
         '. . d d d d i i i i i i';
@@ -74,10 +77,10 @@ and some meta info that can appear below the description (like blog hero).
     gap: 32px;
     align-items: flex-start;
 
-    @include md {
+    @include mx.md {
       gap: 40px;
     }
-    @include lg {
+    @include mx.lg {
       gap: 56px;
     }
 
@@ -89,24 +92,24 @@ and some meta info that can appear below the description (like blog hero).
 
 .project-hero__description {
   grid-area: d;
-  font-size: px2rem(22);
+  font-size: fn.rem(22);
   line-height: 1.5;
   margin: 16px 0 0;
 
-  @include md {
-    font-size: px2rem(20);
+  @include mx.md {
+    font-size: fn.rem(20);
     margin-block-start: 24px;
   }
-  @include lg {
+  @include mx.lg {
     margin-block-start: 56px;
   }
-  @include xl {
-    font-size: px2rem(24);
+  @include mx.xl {
+    font-size: fn.rem(24);
   }
 
   :where(.tag-list) {
     margin-block-start: 24px;
-    @include lg {
+    @include mx.lg {
       margin-block-start: 40px;
     }
   }
@@ -114,15 +117,15 @@ and some meta info that can appear below the description (like blog hero).
   :where(.sk-btn) {
     margin-block-start: 32px;
 
-    @include md {
+    @include mx.md {
       margin-block-start: 40px;
     }
-    @include lg {
+    @include mx.lg {
       margin-block-start: 56px;
     }
 
     :where(svg) {
-      width: px2rem(16);
+      width: fn.rem(16);
       aspect-ratio: 1;
     }
   }
@@ -130,15 +133,15 @@ and some meta info that can appear below the description (like blog hero).
 
 .project-hero__img {
   grid-area: i;
-  @include break-grid;
+  @include mx.break-grid;
 
-  @include sm {
-    @include undo-break-grid;
+  @include mx.sm {
+    @include mx.undo-break-grid;
   }
-  @include md {
-    @include break-grid-right;
+  @include mx.md {
+    @include mx.break-grid-right;
   }
-  @include xxxl {
-    @include undo-break-grid;
+  @include mx.xxxl {
+    @include mx.undo-break-grid;
   }
 }

--- a/cdhweb/static_src/global/components/pull-quote.scss
+++ b/cdhweb/static_src/global/components/pull-quote.scss
@@ -1,26 +1,29 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .pull-quote {
-  @include outdented-line-block;
+  @include mx.outdented-line-block;
 }
 
 .pull-quote__quote {
-  font-size: px2rem(24);
+  font-size: fn.rem(24);
   line-height: 1.25;
 
-  @include sm {
-    font-size: px2rem(32);
+  @include mx.sm {
+    font-size: fn.rem(32);
   }
 }
 
 .pull-quote__citation {
   font-style: italic;
   margin-block-start: 16px;
-  font-size: px2rem(20);
+  font-size: fn.rem(20);
 
   // for endash pseudo content:
   position: relative;
   padding-left: 1.5ch;
 
-  @include sm {
+  @include mx.sm {
     margin-block-start: 24px;
   }
 

--- a/cdhweb/static_src/global/components/search-form.scss
+++ b/cdhweb/static_src/global/components/search-form.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 // .search-form {
 // }
 
@@ -10,7 +13,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px 16px;
-  font-size: px2rem(15);
+  font-size: fn.rem(15);
   line-height: 1.33;
   font-weight: bold;
 
@@ -25,7 +28,7 @@
     flex-direction: column;
     gap: 8px;
 
-    @include md {
+    @include mx.md {
       flex-direction: row;
       gap: 8px 40px;
     }

--- a/cdhweb/static_src/global/components/sidenav.scss
+++ b/cdhweb/static_src/global/components/sidenav.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .sidenav {
   --three-dee-side-size: 18px;
   --three-dee-border-width: 6px;
@@ -8,20 +11,20 @@
   padding-inline: var(--pad-x);
   padding-block: 24px 0;
 
-  @include three-dee-box;
+  @include mx.three-dee-box;
 
-  @include sm {
+  @include mx.sm {
     --three-dee-border-width: 8px;
   }
-  @include xl {
-    max-width: px2rem(222);
+  @include mx.xl {
+    max-width: fn.rem(222);
     position: sticky;
     top: 24px;
   }
 
   // Sidenav content styles
   :where(h2) {
-    font-size: px2rem(18);
+    font-size: fn.rem(18);
     border-bottom: 1px solid var(--color-brand-100);
     padding-block-end: 18px;
     margin: 0;
@@ -45,7 +48,7 @@
     display: block;
     padding-block: 12px;
     width: fit-content;
-    font-size: px2rem(16);
+    font-size: fn.rem(16);
     text-decoration-line: none;
     font-weight: 400;
 

--- a/cdhweb/static_src/global/components/simple-filter-bar.scss
+++ b/cdhweb/static_src/global/components/simple-filter-bar.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 /* 
 Simple filter `<select>` menu that can appear above a tiles list.
 Used on Events and Blog/News landing page.
@@ -13,19 +16,19 @@ Layout code currently assumes there's only one label & select.
   align-items: center;
   gap: 8px;
 
-  @include sm {
+  @include mx.sm {
     justify-content: end;
   }
 
   :where(label) {
     font-weight: bold;
-    font-size: px2rem(17);
+    font-size: fn.rem(17);
     line-height: 1.33;
   }
   :where(select) {
     flex-grow: 1;
 
-    @include sm {
+    @include mx.sm {
       flex-grow: unset;
       width: auto;
       max-width: 100%;

--- a/cdhweb/static_src/global/components/site-alert.scss
+++ b/cdhweb/static_src/global/components/site-alert.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .alert-banner {
   --alert-accent-color: var(--color-brand-100);
   --alert-bg-color: var(--color-brand-5);
@@ -31,7 +34,7 @@
   // c = content (including dismiss button)
   grid-template-areas: 'd c c c c c c c c c c c';
 
-  @include lg {
+  @include mx.lg {
     grid-template-areas: 'd d c c c c c c c c c c';
   }
 }
@@ -47,7 +50,7 @@
   justify-content: end;
   padding: 6px 4px;
 
-  @include lg {
+  @include mx.lg {
     padding: 20px 8px;
   }
 
@@ -62,10 +65,10 @@
   background-color: var(--alert-bg-color);
   position: relative; // for pseudo element placement
 
-  font-size: px2rem(16);
+  font-size: fn.rem(16);
   padding-block: 8px;
 
-  @include lg {
+  @include mx.lg {
     padding-block: 16px;
   }
 
@@ -82,7 +85,7 @@
 }
 
 .alert-banner__heading {
-  font-size: px2rem(20);
+  font-size: fn.rem(20);
 }
 
 // Wrapper for a) text and b) dismiss button
@@ -94,7 +97,7 @@
 }
 
 .alert-banner__text {
-  max-inline-size: px2rem(1080);
+  max-inline-size: fn.rem(1080);
 }
 
 .alert-banner__dismiss-btn {
@@ -106,7 +109,7 @@
   padding: 4px;
 
   :where(svg) {
-    width: px2rem(18);
+    width: fn.rem(18);
     aspect-ratio: 1;
   }
 }

--- a/cdhweb/static_src/global/components/standard-hero.scss
+++ b/cdhweb/static_src/global/components/standard-hero.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 // has `.grid-standard`
 .standard-hero {
   --title-top-space: 40px;
@@ -13,28 +16,28 @@
     't t t t t t t t t t t t'
     'd d d d d d d d d d d d';
 
-  @include sm {
+  @include mx.sm {
     margin-block-end: 120px;
   }
 
-  @include md {
+  @include mx.md {
     --title-top-space: 64px;
 
     grid-template-areas:
       't t t t t t t t t t t t'
       '. d d d d d d d d d d d';
   }
-  @include lg {
+  @include mx.lg {
     --title-top-space: 80px;
 
     grid-template-areas:
       '. t t t t t t t t t t .'
       '. . d d d d d d d d d .';
   }
-  @include xl {
+  @include mx.xl {
     --title-top-space: 104px;
   }
-  @include xxl {
+  @include mx.xxl {
     --title-top-space: 160px;
     grid-template-areas:
       '. t t t t t t t t t . .'
@@ -48,12 +51,12 @@
       't t t t t t t t t t t t'
       'd d d d d d d d d d d d';
 
-    @include md {
+    @include mx.md {
       grid-template-areas:
         't t t t t t i i i i i i'
         '. d d d d d i i i i i i';
     }
-    @include lg {
+    @include mx.lg {
       grid-template-areas:
         '. t t t t t i i i i i i'
         '. . d d d d i i i i i i';
@@ -68,34 +71,34 @@
 
 .standard-hero__description {
   grid-area: d;
-  font-size: px2rem(22);
+  font-size: fn.rem(22);
   line-height: 1.5;
   margin: 16px 0 0;
 
-  @include md {
-    font-size: px2rem(20);
+  @include mx.md {
+    font-size: fn.rem(20);
     margin-block-start: 24px;
   }
-  @include lg {
+  @include mx.lg {
     margin-block-start: 56px;
   }
-  @include xl {
-    font-size: px2rem(24);
+  @include mx.xl {
+    font-size: fn.rem(24);
   }
 }
 
 .standard-hero__img {
   grid-area: i;
-  @include break-grid;
+  @include mx.break-grid;
 
-  @include sm {
-    @include undo-break-grid;
+  @include mx.sm {
+    @include mx.undo-break-grid;
   }
-  @include md {
-    @include break-grid-right;
+  @include mx.md {
+    @include mx.break-grid-right;
   }
 
-  @include xxxl {
-    @include undo-break-grid;
+  @include mx.xxxl {
+    @include mx.undo-break-grid;
   }
 }

--- a/cdhweb/static_src/global/components/table.scss
+++ b/cdhweb/static_src/global/components/table.scss
@@ -1,3 +1,5 @@
+@use '../functions/fn';
+
 .table-scroll-wrapper {
   overflow-x: auto;
 }
@@ -8,7 +10,7 @@
   border-collapse: separate;
 
   color: var(--color-grey-110);
-  font-size: px2rem(18);
+  font-size: fn.rem(18);
   text-align: left;
 }
 
@@ -33,12 +35,12 @@
 
 .table__caption {
   text-align: left;
-  font-size: px2rem(17);
+  font-size: fn.rem(17);
   font-weight: 900;
   margin-block-end: 16px;
 }
 
 .table__notes {
-  font-size: px2rem(14);
+  font-size: fn.rem(14);
   margin-block-start: 12px;
 }

--- a/cdhweb/static_src/global/components/tag.scss
+++ b/cdhweb/static_src/global/components/tag.scss
@@ -1,3 +1,5 @@
+@use '../functions/fn';
+
 .tag-list {
   display: flex;
   flex-wrap: wrap;
@@ -6,7 +8,7 @@
 
 .tag {
   text-align: center;
-  font-size: px2rem(13);
+  font-size: fn.rem(13);
   line-height: 1;
   font-weight: bold;
   position: relative;

--- a/cdhweb/static_src/global/components/tiles.scss
+++ b/cdhweb/static_src/global/components/tiles.scss
@@ -1,11 +1,14 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .tiles--featured {
   // The "featured" setting (i.e. full bleed bg) is only designed to work on the homepage.
   // It could be used on any page without a side-nav in theory, but that's not in scope.
   .template-home & {
-    @include full-bleed-bg(var(--color-grey-5));
+    @include mx.full-bleed-bg(var(--color-grey-5));
     padding-block: 40px;
 
-    @include md {
+    @include mx.md {
       padding-block: 72px;
     }
   }
@@ -24,20 +27,20 @@
   :where(h2) {
     margin-bottom: 0;
 
-    @include md {
+    @include mx.md {
       margin-inline-start: calc(-1 * var(--content-outdent));
     }
   }
 
   :where(a) {
-    font-size: px2rem(14);
+    font-size: fn.rem(14);
   }
 }
 
 .tiles__intro {
   margin-block-end: 40px;
 
-  @include sm {
+  @include mx.sm {
     margin-block-end: 64px;
   }
 }
@@ -46,20 +49,17 @@
   display: grid;
   row-gap: 40px;
 
-  @include sm {
-    grid-template-columns: repeat(auto-fill, minmax(px2rem(280), 1fr));
+  @include mx.sm {
+    grid-template-columns: repeat(auto-fill, minmax(fn.rem(280), 1fr));
     column-gap: 28px;
   }
 
   // For tile lists on wider landing pages, make them outdented too.
   :where(
-      :has(
-          .page-layout--with-sidenav-wider,
-          .page-layout--without-sidenav-wider
-        )
-        &
-    ) {
-    @include md {
+    :has(.page-layout--with-sidenav-wider, .page-layout--without-sidenav-wider)
+      &
+  ) {
+    @include mx.md {
       margin-inline-start: calc(-1 * var(--content-outdent));
     }
   }
@@ -90,18 +90,18 @@
     // causes layout bugs.
     grid-column: 1 / -1;
 
-    @include lg {
+    @include mx.lg {
       grid-column: span 2;
     }
   }
 }
 
-@container featured-tile (min-width: #{px2rem(400)}) {
+@container featured-tile (min-width: #{fn.rem(400)}) {
   .tile--featured {
     grid-template-rows: 1fr;
     grid-template-columns: 0.9fr 1fr;
     height: 100%;
-    min-height: px2rem(250);
+    min-height: fn.rem(250);
 
     .tile__img-wrapper {
       grid-column: 1;
@@ -132,22 +132,22 @@
   padding: 24px 12px;
 
   // Default. Some text elements get different treatment.
-  font-size: px2rem(16);
+  font-size: fn.rem(16);
   line-height: 1.5;
 
   :where(h2, h3) {
-    font-size: px2rem(24);
+    font-size: fn.rem(24);
     font-weight: 900;
     margin-block-end: 12px;
   }
 }
 
 .tile__event-date {
-  font-size: px2rem(16);
+  font-size: fn.rem(16);
 }
 
 .tile__event-speakers {
-  font-size: px2rem(18);
+  font-size: fn.rem(18);
 }
 
 .tile__link {

--- a/cdhweb/static_src/global/components/video.scss
+++ b/cdhweb/static_src/global/components/video.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 // Apply to both the video block (.sk-video__iframe) and the
 // hosted video block (which we can't access the DOM for)
 .block--video :where(iframe) {
@@ -8,12 +11,12 @@
 }
 
 .sk-video__transcript {
-  --transcript-side-pad: #{px2rem(20)};
+  --transcript-side-pad: #{fn.rem(20)};
 
   margin-block-start: 16px;
   border: 1px solid var(--color-brand-100);
   background: var(--color-brand-5);
-  font-size: px2rem(16);
+  font-size: fn.rem(16);
 
   // This site uses two-tone icons with a built-in shadow.
   // That means we can't simply flip the chevron – it needs to
@@ -46,13 +49,13 @@
 .sk-video__transcript-summary {
   list-style: none;
   cursor: pointer;
-  padding: px2rem(16) var(--transcript-side-pad);
+  padding: fn.rem(16) var(--transcript-side-pad);
   display: flex;
   align-items: center;
-  gap: px2rem(6);
+  gap: fn.rem(6);
   line-height: 1.25;
   font-weight: 500;
-  @include link-style;
+  @include mx.link-style;
 
   &::marker,
   &::-webkit-details-marker {
@@ -69,5 +72,5 @@
 }
 
 .sk-video__transcript-content {
-  padding: px2rem(16) var(--transcript-side-pad);
+  padding: fn.rem(16) var(--transcript-side-pad);
 }

--- a/cdhweb/static_src/global/css-variables.scss
+++ b/cdhweb/static_src/global/css-variables.scss
@@ -1,3 +1,3 @@
-@import './css-variables/palette';
-@import './css-variables/typography';
-@import './css-variables/layout';
+@use './css-variables/palette';
+@use './css-variables/typography';
+@use './css-variables/layout';

--- a/cdhweb/static_src/global/css-variables/layout.scss
+++ b/cdhweb/static_src/global/css-variables/layout.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 // =============================================================================
 // Custom properties (variables) the standard grid, gaps and page gutters.
 // Mainly used by the layout utility classes, and also to make things full-bleed
@@ -9,31 +12,31 @@
   --standard-cols: 12;
   --standard-gap: 16px;
   --page-gutter: 16px;
-  --content-max-width: #{px2rem(1770)};
-  --reading-max-width: #{px2rem(865)};
+  --content-max-width: #{fn.rem(1770)};
+  --reading-max-width: #{fn.rem(865)};
   --streamfield-space-xs: 16px;
   --streamfield-space-sm: 24px;
   --streamfield-space-lg: 56px;
   --content-outdent: 0px; // px unit present so calc()s don't break
-  --form-field-height: #{px2rem(40)};
+  --form-field-height: #{fn.rem(40)};
 
-  @include sm {
+  @include mx.sm {
     --standard-gap: 24px;
     --page-gutter: 24px;
   }
-  @include md {
+  @include mx.md {
     --streamfield-space-xs: 24px;
     --streamfield-space-sm: 40px;
     --streamfield-space-lg: 80px;
     --content-outdent: 72px;
   }
-  @include lg {
+  @include mx.lg {
     --streamfield-space-lg: 104px;
   }
-  @include xl {
+  @include mx.xl {
     --content-outdent: 104px;
   }
-  @include xxl {
+  @include mx.xxl {
     --content-outdent: 128px;
   }
 }

--- a/cdhweb/static_src/global/elements/forms.scss
+++ b/cdhweb/static_src/global/elements/forms.scss
@@ -1,3 +1,5 @@
+@use '../functions/fn';
+
 button {
   // mobile safari's UA is a bit different, so we need to explicitly override it
   color: currentColor;
@@ -9,7 +11,7 @@ input {
     width: 100%;
     border: 1px solid var(--color-grey-60);
     border-radius: 8px;
-    font-size: px2rem(16);
+    font-size: fn.rem(16);
     height: var(--form-field-height);
     padding-inline: 16px;
   }
@@ -27,7 +29,7 @@ select {
   padding-inline: 16px 38px;
   border: 1px solid var(--color-grey-60);
   border-radius: 8px;
-  font-size: px2rem(16);
+  font-size: fn.rem(16);
   font-weight: bold;
   height: var(--form-field-height);
 }

--- a/cdhweb/static_src/global/elements/page.scss
+++ b/cdhweb/static_src/global/elements/page.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 @view-transition {
   navigation: auto;
 }
@@ -24,11 +27,11 @@ html {
 body {
   color: var(--color-text, var(--color-black));
   font-family: var(--font-family-primary);
-  font-size: px2rem(20);
+  font-size: fn.rem(20);
   line-height: var(--base-line-height);
 
-  @include xl {
-    font-size: px2rem(22);
+  @include mx.xl {
+    font-size: fn.rem(22);
   }
 }
 

--- a/cdhweb/static_src/global/elements/typography.scss
+++ b/cdhweb/static_src/global/elements/typography.scss
@@ -1,21 +1,24 @@
+@use '../functions/fn';
+@use '../mixins/mx';
+
 h1 {
-  @include h1;
+  @include mx.h1;
 }
 h2 {
-  @include h2;
   scroll-margin-top: 0.8em; // jumplink headings
+  @include mx.h2;
 }
 h3 {
-  @include h3;
+  @include mx.h3;
 }
 h4 {
-  @include h4;
+  @include mx.h4;
 }
 h5,
 h6 {
-  @include h5;
+  @include mx.h5;
 }
 
 a {
-  @include link-style;
+  @include mx.link-style;
 }

--- a/cdhweb/static_src/global/functions/fn.scss
+++ b/cdhweb/static_src/global/functions/fn.scss
@@ -1,11 +1,13 @@
+@use 'sass:meta';
 @use 'sass:math';
+
 // =============================================================================
 // Functions
 // =============================================================================
 
 // Used by `rem` function
 @function strip-unit($number) {
-  @if type-of($number) == 'number' and not unitless($number) {
+  @if meta.type-of($number) == 'number' and not math.is-unitless($number) {
     @return math.div($number, ($number * 0 + 1));
   }
 
@@ -13,13 +15,13 @@
 }
 
 // Convert pixels to rems
-@function px2rem($size) {
+@function rem($size) {
   $rem-size: math.div(strip-unit($size), strip-unit(16));
   @return #{$rem-size}rem;
 }
 
 // Convert pixels to ems
 // (USE FOR BREAKPOINTS ONLY)
-@function px2em($size) {
-  @return math.div($size, 16px) * 1em;
+@function em($size) {
+  @return math.div(strip-unit($size), strip-unit(16)) * 1em;
 }

--- a/cdhweb/static_src/global/layout/content-width.scss
+++ b/cdhweb/static_src/global/layout/content-width.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .content-width {
-  @include content-width;
+  @include mx.content-width;
 }

--- a/cdhweb/static_src/global/layout/grid.scss
+++ b/cdhweb/static_src/global/layout/grid.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .grid-standard {
-  @include grid-standard;
+  @include mx.grid-standard;
 }

--- a/cdhweb/static_src/global/layout/page-layout.scss
+++ b/cdhweb/static_src/global/layout/page-layout.scss
@@ -1,12 +1,15 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 // Has `.grid-standard`
 .page-layout {
   & > * {
     grid-column: 1 / -1;
 
-    @include md {
+    @include mx.md {
       grid-column: 2 / -1;
     }
-    @include lg {
+    @include mx.lg {
       grid-column: 3 / -2;
     }
   }
@@ -15,10 +18,10 @@
 // From xl, with- and without-sidenav layouts diverge
 .page-layout--without-sidenav {
   // m = main content
-  @include xl {
+  @include mx.xl {
     grid-template-areas: '. . m m m m m m m m . .';
   }
-  @include xxxl {
+  @include mx.xxxl {
     grid-template-areas: '. . m m m m m m m . . .';
   }
 }
@@ -27,10 +30,10 @@
   // s = side-nav
   // Note, we must keep the extra space between the `s` and `m` because otherwise
   // content that has the negative "outdent" (e.g. headings) can collide with the sidenav.
-  @include xl {
+  @include mx.xl {
     grid-template-areas: 's s s . m m m m m m m .';
   }
-  @include xxxl {
+  @include mx.xxxl {
     grid-template-areas: 's s . m m m m m m m . .';
   }
 }
@@ -38,26 +41,26 @@
 // "wider" variants, for tile landing pages such as people, events & blog/news.
 // Similar to above, but uses an extra col for content sometimes.
 .page-layout--without-sidenav-wider {
-  @include xl {
+  @include mx.xl {
     grid-template-areas: '. . m m m m m m m m m .';
   }
-  @include xxxl {
+  @include mx.xxxl {
     grid-template-areas: '. . m m m m m m m m . .';
   }
 }
 .page-layout--with-sidenav-wider {
   // Note, we must keep the extra space between the `s` and `m` because otherwise
   // content that has the negative "outdent" (e.g. headings) can collide with the sidenav.
-  @include xl {
+  @include mx.xl {
     grid-template-areas: 's s s . m m m m m m m .';
   }
-  @include xxxl {
+  @include mx.xxxl {
     grid-template-areas: 's s . m m m m m m m . .';
   }
 }
 
 .page-layout__main-content {
-  @include xl {
+  @include mx.xl {
     grid-area: m;
   }
 }
@@ -66,14 +69,14 @@
   // Vertical space between sidenav and main content when stacked:
   margin-block-start: 56px;
 
-  @include sm {
+  @include mx.sm {
     margin-block-start: 80px;
   }
-  @include md {
+  @include mx.md {
     margin-block-start: 104px;
   }
 
-  @include xl {
+  @include mx.xl {
     grid-area: s;
     margin-block-start: 0; // unstacked now
   }

--- a/cdhweb/static_src/global/layout/streamfields.scss
+++ b/cdhweb/static_src/global/layout/streamfields.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .streamfields-wrapper {
   // The flex column layout is to disable collapsing margins.
   // Usually collapsing margins is fine, but the 3d boxes have absolute-
@@ -14,16 +17,16 @@
     // Cases where there should be a `sm` space above:
     &:where(
         :is(
-            .block--image,
-            .block--table,
-            .block--note,
-            .block--paragraph,
-            .block--migrated-content,
-            .block--pull-quote,
-            .block--accordion:not(:has(> h2)),
-            .block--video:not(:has(> h2)),
-            .code-toolbar
-          )
+          .block--image,
+          .block--table,
+          .block--note,
+          .block--paragraph,
+          .block--migrated-content,
+          .block--pull-quote,
+          .block--accordion:not(:has(> h2)),
+          .block--video:not(:has(> h2)),
+          .code-toolbar
+        )
       ) {
       margin-block-start: var(--streamfield-space-sm);
     }
@@ -58,12 +61,12 @@
   // (Note: `.block--paragraph > h2` can't happen in the new CMS fields,
   // but may happen with migrated content.
   :where(
-      .block--heading,
-      .block--accordion > h2,
-      .block--video > h2,
-      .block--paragraph > h2
-    ) {
-    @include md {
+    .block--heading,
+    .block--accordion > h2,
+    .block--video > h2,
+    .block--paragraph > h2
+  ) {
+    @include mx.md {
       margin-left: calc(-1 * var(--content-outdent));
     }
   }

--- a/cdhweb/static_src/global/migrated-content.scss
+++ b/cdhweb/static_src/global/migrated-content.scss
@@ -1,10 +1,12 @@
+@use './mixins/mx';
+
 /*
     Regarding content migrated as part of Springload's 2024 rebuild.
     Existing content was dumped into a "migrated" content streamfield block.
 */
 .block--migrated-content {
   :where(h2) {
-    @include md {
+    @include mx.md {
       margin-left: calc(-1 * var(--content-outdent));
     }
   }

--- a/cdhweb/static_src/global/mixins.scss
+++ b/cdhweb/static_src/global/mixins.scss
@@ -1,9 +1,0 @@
-@import './mixins/breakpoints';
-@import './mixins/grid';
-@import './mixins/content-width';
-@import './mixins/typography';
-@import './mixins/btn';
-@import './mixins/visibility';
-@import './mixins/outdented-line-block';
-@import './mixins/full-bleed-bg';
-@import './mixins/three-dee-box';

--- a/cdhweb/static_src/global/mixins/breakpoints.scss
+++ b/cdhweb/static_src/global/mixins/breakpoints.scss
@@ -1,3 +1,5 @@
+@use '../functions/fn';
+
 $breakpoint-sm: 500px;
 $breakpoint-md: 768px;
 $breakpoint-lg: 1024px;
@@ -6,32 +8,32 @@ $breakpoint-xxl: 1440px;
 $breakpoint-xxxl: 1920px;
 
 @mixin sm {
-  @media (min-width: px2em($breakpoint-sm)) {
+  @media (min-width: fn.em($breakpoint-sm)) {
     @content;
   }
 }
 @mixin md {
-  @media (min-width: px2em($breakpoint-md)) {
+  @media (min-width: fn.em($breakpoint-md)) {
     @content;
   }
 }
 @mixin lg {
-  @media (min-width: px2em($breakpoint-lg)) {
+  @media (min-width: fn.em($breakpoint-lg)) {
     @content;
   }
 }
 @mixin xl {
-  @media (min-width: px2em($breakpoint-xl)) {
+  @media (min-width: fn.em($breakpoint-xl)) {
     @content;
   }
 }
 @mixin xxl {
-  @media (min-width: px2em($breakpoint-xxl)) {
+  @media (min-width: fn.em($breakpoint-xxl)) {
     @content;
   }
 }
 @mixin xxxl {
-  @media (min-width: px2em($breakpoint-xxxl)) {
+  @media (min-width: fn.em($breakpoint-xxxl)) {
     @content;
   }
 }

--- a/cdhweb/static_src/global/mixins/btn.scss
+++ b/cdhweb/static_src/global/mixins/btn.scss
@@ -1,6 +1,10 @@
 @use '../functions/fn';
-@use './breakpoints' as bp;
 @use './typography' as typo;
+
+// Note, importing breakpoints only as `mx` here to make searching
+// for instances of breakpoints the same across the codebase
+// (regardless of whether we're inside the mixins directory)
+@use './breakpoints' as mx;
 
 @mixin btn {
   // <button> fixes (in case it's literally a button)
@@ -28,7 +32,7 @@
   width: 100%;
   text-align: center;
 
-  @include bp.sm {
+  @include mx.sm {
     width: auto;
     max-width: fit-content;
   }

--- a/cdhweb/static_src/global/mixins/btn.scss
+++ b/cdhweb/static_src/global/mixins/btn.scss
@@ -1,3 +1,7 @@
+@use '../functions/fn';
+@use './breakpoints' as bp;
+@use './typography' as typo;
+
 @mixin btn {
   // <button> fixes (in case it's literally a button)
   background: none;
@@ -6,12 +10,12 @@
   cursor: pointer;
 
   text-decoration-line: none;
-  font-size: px2rem(16);
+  font-size: fn.rem(16);
   font-weight: bold;
   background-color: var(--btn-bg);
   border: 2px solid var(--btn-border-color);
   color: var(--btn-color);
-  border-radius: px2rem(32);
+  border-radius: fn.rem(32);
   padding: 8px 24px;
   line-height: 1.5;
 
@@ -24,7 +28,7 @@
   width: 100%;
   text-align: center;
 
-  @include sm {
+  @include bp.sm {
     width: auto;
     max-width: fit-content;
   }
@@ -73,6 +77,6 @@
   --btn-focus-ring-color: var(--color-brand-120);
 
   border-radius: 0;
-  @include link-style;
+  @include typo.link-style;
   padding-inline: 0;
 }

--- a/cdhweb/static_src/global/mixins/mx.scss
+++ b/cdhweb/static_src/global/mixins/mx.scss
@@ -1,0 +1,11 @@
+@use '../functions/fn';
+
+@forward './breakpoints';
+@forward './grid';
+@forward './content-width';
+@forward './typography';
+@forward './btn';
+@forward './visibility';
+@forward './outdented-line-block';
+@forward './full-bleed-bg';
+@forward './three-dee-box';

--- a/cdhweb/static_src/global/mixins/outdented-line-block.scss
+++ b/cdhweb/static_src/global/mixins/outdented-line-block.scss
@@ -1,8 +1,10 @@
+@use './breakpoints' as bp;
+
 @mixin outdented-line-block {
   position: relative;
   padding-inline-start: 32px;
 
-  @include md {
+  @include bp.md {
     padding-inline-start: 0;
   }
 

--- a/cdhweb/static_src/global/mixins/outdented-line-block.scss
+++ b/cdhweb/static_src/global/mixins/outdented-line-block.scss
@@ -1,10 +1,13 @@
-@use './breakpoints' as bp;
+// Note, importing breakpoints only as `mx` here to make searching
+// for instances of breakpoints the same across the codebase
+// (regardless of whether we're inside the mixins directory)
+@use './breakpoints' as mx;
 
 @mixin outdented-line-block {
   position: relative;
   padding-inline-start: 32px;
 
-  @include bp.md {
+  @include mx.md {
     padding-inline-start: 0;
   }
 

--- a/cdhweb/static_src/global/mixins/three-dee-box.scss
+++ b/cdhweb/static_src/global/mixins/three-dee-box.scss
@@ -1,4 +1,7 @@
-@use './breakpoints' as bp;
+// Note, importing breakpoints only as `mx` here to make searching
+// for instances of breakpoints the same across the codebase
+// (regardless of whether we're inside the mixins directory)
+@use './breakpoints' as mx;
 
 /**
     Fancy 3D-lookin' box.
@@ -26,7 +29,7 @@
   // `margin-block-end` on your component as needed.
   margin-block-end: var(--side-size);
 
-  @include bp.xl {
+  @include mx.xl {
     // Undo capped width now it's likely spaced away from the page edge.
     width: 100%;
   }

--- a/cdhweb/static_src/global/mixins/three-dee-box.scss
+++ b/cdhweb/static_src/global/mixins/three-dee-box.scss
@@ -1,3 +1,5 @@
+@use './breakpoints' as bp;
+
 /**
     Fancy 3D-lookin' box.
     - Default look: white content area, teal border/sides (overridable). 
@@ -24,7 +26,7 @@
   // `margin-block-end` on your component as needed.
   margin-block-end: var(--side-size);
 
-  @include xl {
+  @include bp.xl {
     // Undo capped width now it's likely spaced away from the page edge.
     width: 100%;
   }

--- a/cdhweb/static_src/global/mixins/typography.scss
+++ b/cdhweb/static_src/global/mixins/typography.scss
@@ -1,58 +1,61 @@
+@use '../functions/fn';
+@use './breakpoints' as bp;
+
 // Mixins for typography
 
 // These mixins are intended to allow you to style (e.g.) an h2 to look like (e.g.) an h3.
 @mixin h1 {
-  font-size: px2rem(36);
+  font-size: fn.rem(36);
   line-height: 1;
   font-weight: 900;
   text-wrap: balance;
 
-  @include md {
-    font-size: px2rem(48);
+  @include bp.md {
+    font-size: fn.rem(48);
   }
 
-  @include xl {
-    font-size: px2rem(56);
+  @include bp.xl {
+    font-size: fn.rem(56);
   }
 }
 
 @mixin h2 {
-  font-size: px2rem(32);
+  font-size: fn.rem(32);
   line-height: 1.125;
   font-weight: 900;
 
-  @include xl {
-    font-size: px2rem(36);
+  @include bp.xl {
+    font-size: fn.rem(36);
   }
 }
 
 @mixin h3 {
-  font-size: px2rem(24);
+  font-size: fn.rem(24);
   line-height: 1.125;
   font-weight: 900;
 
-  @include xl {
-    font-size: px2rem(28);
+  @include bp.xl {
+    font-size: fn.rem(28);
   }
 }
 
 @mixin h4 {
-  font-size: px2rem(20);
+  font-size: fn.rem(20);
   line-height: 1.125;
   font-weight: 900;
 
-  @include xl {
-    font-size: px2rem(24);
+  @include bp.xl {
+    font-size: fn.rem(24);
   }
 }
 
 @mixin h5 {
-  font-size: px2rem(20);
+  font-size: fn.rem(20);
   line-height: 1.125;
   font-weight: bold;
 
-  @include xl {
-    font-size: px2rem(24);
+  @include bp.xl {
+    font-size: fn.rem(24);
   }
 }
 

--- a/cdhweb/static_src/global/mixins/typography.scss
+++ b/cdhweb/static_src/global/mixins/typography.scss
@@ -1,5 +1,9 @@
 @use '../functions/fn';
-@use './breakpoints' as bp;
+
+// Note, importing breakpoints only as `mx` here to make searching
+// for instances of breakpoints the same across the codebase
+// (regardless of whether we're inside the mixins directory)
+@use './breakpoints' as mx;
 
 // Mixins for typography
 
@@ -10,11 +14,11 @@
   font-weight: 900;
   text-wrap: balance;
 
-  @include bp.md {
+  @include mx.md {
     font-size: fn.rem(48);
   }
 
-  @include bp.xl {
+  @include mx.xl {
     font-size: fn.rem(56);
   }
 }
@@ -24,7 +28,7 @@
   line-height: 1.125;
   font-weight: 900;
 
-  @include bp.xl {
+  @include mx.xl {
     font-size: fn.rem(36);
   }
 }
@@ -34,7 +38,7 @@
   line-height: 1.125;
   font-weight: 900;
 
-  @include bp.xl {
+  @include mx.xl {
     font-size: fn.rem(28);
   }
 }
@@ -44,7 +48,7 @@
   line-height: 1.125;
   font-weight: 900;
 
-  @include bp.xl {
+  @include mx.xl {
     font-size: fn.rem(24);
   }
 }
@@ -54,7 +58,7 @@
   line-height: 1.125;
   font-weight: bold;
 
-  @include bp.xl {
+  @include mx.xl {
     font-size: fn.rem(24);
   }
 }

--- a/cdhweb/static_src/global/pages/project-page.scss
+++ b/cdhweb/static_src/global/pages/project-page.scss
@@ -1,3 +1,6 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 /*
 Project page has a similar layout to the standard page with sidenav,
 except the sidenav is replaced by a meta-details box, which sits to
@@ -14,14 +17,14 @@ the right of the content (when unstacked).
     's s s s s s s s s s s s'
     'm m m m m m m m m m m m';
 
-  @include sm {
+  @include mx.sm {
     row-gap: 80px;
   }
-  @include lg {
+  @include mx.lg {
     grid-template-areas: 'm m m m m m m m s s s s';
   }
 
-  @include xl {
+  @include mx.xl {
     grid-template-areas: '. . m m m m m m m s s s';
   }
 }
@@ -31,36 +34,37 @@ the right of the content (when unstacked).
 }
 
 .project-page__side-content {
-  grid-area: s;
+  @include mx.three-dee-box;
+  & {
+    grid-area: s;
+    position: relative;
 
-  position: relative;
-  @include three-dee-box;
+    padding: 20px 32px;
+    font-size: fn.rem(16);
 
-  padding: 20px 32px;
-  font-size: px2rem(16);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+  }
 
-  display: flex;
-  flex-wrap: wrap;
-  gap: 24px;
-
-  @include sm {
+  @include mx.sm {
     padding-inline: 48px;
   }
-  @include md {
+  @include mx.md {
     padding-inline: 24px;
   }
-  @include lg {
+  @include mx.lg {
     align-self: start;
   }
 
   :where(h2) {
-    font-size: px2rem(16);
+    font-size: fn.rem(16);
     font-weight: 900;
     line-height: 1.125;
     margin-block-end: 16px;
   }
   :where(h3) {
-    font-size: px2rem(13);
+    font-size: fn.rem(13);
     font-weight: bold;
     line-height: 1.125;
     margin-block-end: 4px;
@@ -78,7 +82,7 @@ the right of the content (when unstacked).
 }
 
 .project-page__side-content-block {
-  flex: 1 1 px2rem(185);
+  flex: 1 1 fn.rem(185);
 }
 
 .project-page__side-content-item {

--- a/cdhweb/static_src/global/pages/projects-landing.scss
+++ b/cdhweb/static_src/global/pages/projects-landing.scss
@@ -1,10 +1,13 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 // Has `grid-standard`.
 // Uses more cols than other pages, so doesn't use `.page-layout--*`
 .projects-landing {
   > * {
     grid-column: 1 / -1;
 
-    @include md {
+    @include mx.md {
       grid-column: 2 / -2;
     }
   }
@@ -15,21 +18,23 @@
 }
 
 .projects-landing__form {
-  position: relative;
-  @include three-dee-box;
-  padding: 24px;
+  @include mx.three-dee-box;
+  & {
+    position: relative;
+    padding: 24px;
 
-  display: grid;
-  // f = fields (selects and text)
-  // c = checkboxes
-  // b = buttons/links
-  grid-template-areas:
-    'f'
-    'c'
-    'b';
-  gap: 24px;
+    display: grid;
+    // f = fields (selects and text)
+    // c = checkboxes
+    // b = buttons/links
+    grid-template-areas:
+      'f'
+      'c'
+      'b';
+    gap: 24px;
+  }
 
-  @include md {
+  @include mx.md {
     --three-dee-side-size: 56px;
     padding: 32px;
     grid-template-areas:
@@ -37,7 +42,7 @@
       'c c'
       'b b';
   }
-  @include lg {
+  @include mx.lg {
     grid-template-areas:
       'f f'
       'c b';
@@ -49,18 +54,18 @@
   display: grid;
   gap: 20px;
 
-  @include sm {
+  @include mx.sm {
     grid-template-columns: repeat(2, 1fr);
     gap: 16px 24px;
   }
-  @include lg {
+  @include mx.lg {
     grid-template-columns: repeat(4, 1fr);
     column-gap: 24px;
   }
 
   :where(label) {
     font-weight: bold;
-    font-size: px2rem(17);
+    font-size: fn.rem(17);
     line-height: 1.33;
   }
 }
@@ -73,13 +78,13 @@
 
   :where(label) {
     font-weight: bold;
-    font-size: px2rem(15);
+    font-size: fn.rem(15);
     line-height: 1.33;
   }
 }
 .projects-landing__form-btns {
   grid-area: b;
-  @include sm {
+  @include mx.sm {
     justify-self: end;
   }
 

--- a/cdhweb/static_src/global/pages/search.scss
+++ b/cdhweb/static_src/global/pages/search.scss
@@ -1,12 +1,15 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 // has `.grid-standard`
 .search-page {
   & > * {
     grid-column: 1 / -1;
 
-    @include xl {
+    @include mx.xl {
       grid-column: 3 / -2;
     }
-    @include xxxl {
+    @include mx.xxxl {
       grid-column: 3 / -3;
     }
   }
@@ -15,15 +18,15 @@
     margin-block-start: 40px;
     margin-block-end: 24px;
 
-    @include md {
+    @include mx.md {
       margin-block-start: 80px;
     }
-    @include xl {
+    @include mx.xl {
       margin-block-start: 104px;
       margin-block-end: 56px;
       margin-inline-start: calc(-1 * var(--content-outdent));
     }
-    @include xxl {
+    @include mx.xxl {
       margin-block-start: 160px;
     }
   }
@@ -32,32 +35,32 @@
 .search-page__results {
   margin-block-start: 40px;
 
-  @include md {
+  @include mx.md {
     margin-block-start: 80px;
   }
-  @include xl {
+  @include mx.xl {
     margin-block-start: 104px;
   }
 }
 
 .search-page__results-heading {
   margin-block-end: 4px;
-  font-size: px2rem(24);
+  font-size: fn.rem(24);
   font-weight: 900;
 
-  @include sm {
-    font-size: px2rem(28);
+  @include mx.sm {
+    font-size: fn.rem(28);
   }
 }
 
 .search-page__results-summary {
-  font-size: px2rem(16);
+  font-size: fn.rem(16);
   padding-block-end: 20px;
   margin-block-end: 56px;
   border-bottom: 1px solid var(--color-brand-100);
 
-  @include sm {
-    font-size: px2rem(18);
+  @include mx.sm {
+    font-size: fn.rem(18);
   }
 }
 
@@ -69,13 +72,13 @@
   gap: 56px;
 
   :where(h3) {
-    font-size: px2rem(18);
+    font-size: fn.rem(18);
     font-weight: bold;
     margin-block-end: 12px;
     line-height: 1.625;
 
-    @include sm {
-      font-size: px2rem(22);
+    @include mx.sm {
+      font-size: fn.rem(22);
     }
   }
 
@@ -99,12 +102,12 @@
 }
 
 .search-page__result-last-updated {
-  font-size: px2rem(14);
+  font-size: fn.rem(14);
 }
 
 .search-page__form {
   --btn-bg: var(--color-brand-100);
   --btn-color: var(--color-black);
   --btn-bg-hover: Var(--color-brand-110);
-  max-inline-size: px2rem(800);
+  max-inline-size: fn.rem(800);
 }

--- a/cdhweb/static_src/global/rich-text.scss
+++ b/cdhweb/static_src/global/rich-text.scss
@@ -1,3 +1,6 @@
+@use './functions/fn';
+@use './mixins/mx';
+
 // By default, every prose element has a bottom margin.
 // `li` is excluded because list item spacing is handled later on.
 // Same with headings because they have their own, more specific spacing values.
@@ -10,10 +13,10 @@
   // the heading, but are based on the level of that heading.
   // So in the case of `p + h2`, the p gets a big margin-bottom.
   --space-h2-lg: var(--streamfield-space-lg);
-  --space-h3-lg: #{px2rem(40)};
-  --space-h4-lg: #{px2rem(24)};
-  --space-h5-lg: #{px2rem(24)};
-  --space-h6-lg: #{px2rem(24)};
+  --space-h3-lg: #{fn.rem(40)};
+  --space-h4-lg: #{fn.rem(24)};
+  --space-h5-lg: #{fn.rem(24)};
+  --space-h6-lg: #{fn.rem(24)};
 
   --space-h2-sm: var(--streamfield-space-xs);
   --space-h3-sm: calc(var(--space-h3-lg) / 4);
@@ -21,7 +24,7 @@
   --space-h5-sm: calc(var(--space-h5-lg) / 4);
   --space-h6-sm: calc(var(--space-h6-lg) / 4);
 
-  --space-list-items: #{px2rem(8)};
+  --space-list-items: #{fn.rem(8)};
 
   :is(p, ul, ol, blockquote) {
     margin-bottom: var(--space-default);
@@ -60,7 +63,7 @@
   }
 
   :where(.block--paragraph blockquote) {
-    @include outdented-line-block;
+    @include mx.outdented-line-block;
   }
 
   // Headings followed immediately by a heading of a level down

--- a/cdhweb/static_src/global/utilities.scss
+++ b/cdhweb/static_src/global/utilities.scss
@@ -1,1 +1,1 @@
-@import './utilities/show-hide';
+@use './utilities/show-hide';

--- a/cdhweb/static_src/global/utilities/show-hide.scss
+++ b/cdhweb/static_src/global/utilities/show-hide.scss
@@ -1,9 +1,12 @@
+@use '../mixins/mx';
+@use '../functions/fn';
+
 .sr-only {
-  @include visuallyHidden;
+  @include mx.visuallyHidden;
 }
 
 .sr-only-until-focused {
-  @include visuallyHiddenUntilFocused;
+  @include mx.visuallyHiddenUntilFocused;
 }
 
 .u-hidden {
@@ -11,9 +14,9 @@
 }
 
 .u-no-js-hide {
-  @include no-js-hide;
+  @include mx.no-js-hide;
 }
 
 .u-js-hide {
-  @include js-hide;
+  @include mx.js-hide;
 }

--- a/cdhweb/static_src/styles.scss
+++ b/cdhweb/static_src/styles.scss
@@ -3,41 +3,42 @@
 // Should not add any code to the main bundle.
 // i.e. DO NOT add classes here.
 // ================================================
-@import './global/functions';
-@import './global/mixins';
+// @use 'global/sass-variables/var';
+@use './global/functions/fn';
+@use './global/mixins/mx';
 
 // ================================================
 // Code above this line should not output any CSS.
 // ================================================
 
 // CSS variables
-@import './global/css-variables';
+@use './global/css-variables';
 
 // Reset
-@import './global/reset';
+@use './global/reset';
 
 // Fonts. Put font files in this directory (only woff2 is needed).
-@import './global/fonts/fonts';
+@use './global/fonts/fonts';
 
 // Elements
-@import './global/elements/typography';
-@import './global/elements/forms';
-@import './global/elements/page.scss';
+@use './global/elements/typography';
+@use './global/elements/forms' as formElements;
+@use './global/elements/page.scss';
 
 // Layout
-@import './global/layout/content-width.scss';
-@import './global/layout/grid.scss';
-@import './global/layout/page-layout.scss';
-@import './global/layout/streamfields.scss';
+@use './global/layout/content-width.scss';
+@use './global/layout/grid.scss';
+@use './global/layout/page-layout.scss';
+@use './global/layout/streamfields.scss';
 
 // Page templates
-@import './global/pages/search.scss';
-@import './global/pages/projects-landing.scss';
-@import './global/pages/project-page.scss';
-@import './global/pages/error-page.scss';
+@use './global/pages/search.scss';
+@use './global/pages/projects-landing.scss';
+@use './global/pages/project-page.scss';
+@use './global/pages/error-page.scss';
 
 // Spacing between each type of typographic element.
-@import './global/rich-text';
+@use './global/rich-text';
 
 // Components
 
@@ -46,43 +47,43 @@
 // aren't "utilities" (they aren't !important - they're just base styles
 // that can be overridden easily).
 // Should be listed before other components.
-@import './global/components/btn.scss';
-@import './global/components/forms.scss';
-@import './global/components/tag.scss';
+@use './global/components/btn.scss';
+@use './global/components/forms.scss' as formComponents;
+@use './global/components/tag.scss';
 
 // All other components go here:
-@import './global/components/main-nav-mobile.scss';
-@import './global/components/main-nav-desktop.scss';
-@import './global/components/site-alert.scss';
-@import './global/components/skip-link.scss';
-@import './global/components/home-hero.scss';
-@import './global/components/standard-hero.scss';
-@import './global/components/project-hero.scss';
-@import './global/components/person-hero.scss';
-@import './global/components/event-hero.scss';
-@import './global/components/blog-hero.scss';
-@import './global/components/breadcrumbs.scss';
-@import './global/components/jumplinks.scss';
-@import './global/components/sidenav.scss';
-@import './global/components/image.scss';
-@import './global/components/tiles.scss';
-@import './global/components/accordion.scss';
-@import './global/components/cta.scss';
-@import './global/components/note.scss';
-@import './global/components/pull-quote.scss';
-@import './global/components/download.scss';
-@import './global/components/feature.scss';
-@import './global/components/table.scss';
-@import './global/components/video.scss';
-@import './global/components/newsletter.scss';
-@import './global/components/search-form.scss';
-@import './global/components/pagination.scss';
-@import './global/components/simple-filter-bar.scss';
-@import './global/components/footer.scss';
+@use './global/components/main-nav-mobile.scss';
+@use './global/components/main-nav-desktop.scss';
+@use './global/components/site-alert.scss';
+@use './global/components/skip-link.scss';
+@use './global/components/home-hero.scss';
+@use './global/components/standard-hero.scss';
+@use './global/components/project-hero.scss';
+@use './global/components/person-hero.scss';
+@use './global/components/event-hero.scss';
+@use './global/components/blog-hero.scss';
+@use './global/components/breadcrumbs.scss';
+@use './global/components/jumplinks.scss';
+@use './global/components/sidenav.scss';
+@use './global/components/image.scss';
+@use './global/components/tiles.scss';
+@use './global/components/accordion.scss';
+@use './global/components/cta.scss';
+@use './global/components/note.scss';
+@use './global/components/pull-quote.scss';
+@use './global/components/download.scss';
+@use './global/components/feature.scss';
+@use './global/components/table.scss';
+@use './global/components/video.scss';
+@use './global/components/newsletter.scss';
+@use './global/components/search-form.scss';
+@use './global/components/pagination.scss';
+@use './global/components/simple-filter-bar.scss';
+@use './global/components/footer.scss';
 
 // TODO delete migrated content styles once all migrated content is moved from
 // the "migrated" streamfield block and re-created using new (2024) components.
-@import './global/migrated-content.scss';
+@use './global/migrated-content.scss';
 
 // Utility classes. This should go last.
-@import './global/utilities';
+@use './global/utilities';


### PR DESCRIPTION
Sass import overhaul. 

The use of `@import` for sass files is deprecated, so we need to switch to `@use`. We've been doing this on all projects as we get to them.

Getting this out of the way before working on the actual QA-related CSS changes, which I will do next.