### PR TITLE
Fix up the opt-groups on the blog landing page

### DIFF
--- a/templates/blog/blog_landing_page.html
+++ b/templates/blog/blog_landing_page.html
@@ -21,16 +21,20 @@
 
               {# Group months by year #}
               {% for archive_date in date_list %}
-                {% ifchanged %}
+                {% ifchanged archive_date.year %}
+                  {% if forloop.counter > 1 %}
+                    {# Close the previous group, unless we're on the first trip through #}
+                    </optgroup>
+                  {% endif %}
                   <optgroup label="{{ archive_date.year }}">
                 {% endifchanged %}
 
                 {% routablepageurl self 'by-month' year=archive_date.year month=archive_date|date:"m" as blog_url %}
                 <option data-href="{{ blog_url }}" {% if blog_url == request.path  %}selected{% endif %}>{{ archive_date|date:"F" }}</option>
 
-                {% ifchanged %}
-                  </optgroup>
-                {% endifchanged %}
+              {% if forloop.last %}
+                </optgroup> {# close the last optgroup #}
+              {% endif %}
               {% endfor %}
             </select>
           </div>


### PR DESCRIPTION
**Associated Issue(s):** #

### Changes in this PR

- Rebuild the optgroup logic for the blog filtering

### Notes

- `ifchanged` acts on the *content* of the tag, unless a variable is supplied
  - this means that in the "before" state, the optgroups were being opened, but never closed, as the content of the `ifchanged` never changed.

### Reviewer Checklist

- [ ] Check 1
- [ ] Check 2


Before view:
![before-optgroups](https://github.com/user-attachments/assets/836c2308-e524-4bbd-98e3-7ff52961a378)

Before, html:
```html
                  <optgroup label="2025">
                     <option data-href="/blog/2025/06/" >June</option>
                    </optgroup>
                     <option data-href="/blog/2025/05/" >May</option>
                     <option data-href="/blog/2025/03/" >March</option>
                     <option data-href="/blog/2025/02/" >February</option>
                     <option data-href="/blog/2025/01/" >January</option>
                   <optgroup label="2024">
                    <option data-href="/blog/2024/11/" >November</option>
```

After view:
![after-optgroups](https://github.com/user-attachments/assets/ec75f4b0-8167-47b6-8754-b969161dbf97)

After HTML:

```html
<optgroup label="2024">
  <option data-href="/blog/2024/08/" selected>August</option>
  <option data-href="/blog/2024/07/" >July</option>
  <option data-href="/blog/2024/06/" >June</option>
  <option data-href="/blog/2024/05/" >May</option>
  <option data-href="/blog/2024/02/" >February</option>
  <option data-href="/blog/2024/01/" >January</option>
</optgroup>
<optgroup label="2023">
  <option data-href="/blog/2023/12/" >December</option>
```