### PR TITLE
[CDH-54] Return to excluding profiles from page explorer 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ venv.bak/
 
 # npm
 node_modules/
+/collected

--- a/cdhweb/events/templates/events/event.html
+++ b/cdhweb/events/templates/events/event.html
@@ -12,9 +12,9 @@
 
 
 {% block main %}
-<div typeof="schema:Event" class="event-detail">
+<div class="event-detail">
 <header>
-    <h1 property="schema:name">{{ page.title }}</h1>
+    <h1>{{ page.title }}</h1>
 </header>
 
 <div class="details">
@@ -23,10 +23,10 @@
     <ul>
     {% for speaker in page.speakers.all %}
     {# performer == presenter #}
-    <li property="schema:performer" typeof="schema:Person">
-        <h3><span property="schema:name">
+    <li>
+        <h3><span>
             <a
-            {% if speaker.person.profile_url %}href="{{ speaker.person.profile_url }}" property="schema:sameAs"{% endif %}>
+            {% if speaker.person.profile_url %}href="{{ speaker.person.profile_url }}"{% endif %}>
             {{ speaker.person }}</a></span>
         </h3>
         {% if speaker.person.institution %}
@@ -42,19 +42,17 @@
     {% if page.type.name != page.title %}
     <p>{{ page.type }}</p>
     {% endif %}
-    <meta property="schema:startDate" content="{{ page.start_time|date:'c' }}"/>
-    <meta property="schema:endDate" content="{{ page.end_time|date:'c' }}"/>
     <div>{{ page.when }}</div>
 
     {% if page.location %}
-    <div property="schema:location" typeof="{% if page.is_virtual %}schema:VirtualLocation{% else %}schema:Place{% endif %}" class="location">
-        <span property="schema:name">{{ page.location.name }}</span>
+    <div class="location">
+        <span>{{ page.location.name }}</span>
         {% if not page.is_virtual %}
-        <div property="schema:address"
-        {% if page.location.name == page.location.address %}style="display:none"{% endif %}>
-        {{ page.location.address}}</div>
-        {% elif page.join_url %}
-        <div property="schema:url" style="display:none">{{ page.join_url }}</div>
+        <div
+            {% if page.location.name == page.location.address %}style="display:none"{% endif %}
+        >
+            {{ page.location.address}}
+        </div>
         {% endif %}
     </div>
     {% endif %}
@@ -67,17 +65,12 @@
 <div class="description">
     {% if page.image %}
         {% image page.image width-735 as event_img %}
-        <img src="{{ event_img.url }}" alt="{{ page.title }}" property="schema:image"/>
+        <img src="{{ event_img.url }}" alt="{{ page.title }}"/>
     {% endif %}
-    <meta property="schema:url" content="{{ page.full_url }}"/>
-    <div property="schema:description">
+    <div>
     {% include_block page.body %}
     </div>
 </div>
 
 </div>
 {% endblock %}
-
-
-
-

--- a/cdhweb/events/templates/events/snippets/event_card.html
+++ b/cdhweb/events/templates/events/snippets/event_card.html
@@ -1,32 +1,21 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 {# display a single event in card format #}
-{# FIXME: significant overlap with event_detail, esp. for schema properties #}
+
 {% if event.thumbnail %}
     {% image event.thumbnail max-310x240 as event_thumb %}
 {% endif %}
-<div class="card event" typeof="schema:Event">
-    <a property="schema:url" href="{{ event.get_url }}">
+<div class="card event">
+    <a href="{{ event.get_url }}">
         <div class="event-type">{{ event.type }}</div>
         <div class="image" {% if event.thumbnail %}style="background-image:url('{{ event_thumb.url }}')"{% endif %}></div>
         <div class="content">
-            <h2 property="schema:name">{{ event.title }}</h2>
+            <h2 {{ event.title }}</h2>
             <div class="presenter">
                 {% for speaker in event.speakers.all %}
-                <div property="schema:performer" typeof="schema:Person">
-                    <span property="schema:name">{{ speaker.person }}</span>
+                <div>
+                    <span {{ speaker.person }}</span>
                 </div>
                 {% endfor %}
-            </div>
-            <meta property="schema:startDate" content="{{ event.start_time|date:'c' }}"/>
-            <meta property="schema:endDate" content="{{ event.end_time|date:'c' }}"/>
-            {# location is required for schema.org #}
-            <div property="schema:location" typeof="{% if event.is_virtual %}schema:VirtualLocation{% else %}schema:Place{% endif %}">
-                <meta property="schema:name" content="{{ event.location.name }}"/>
-                {% if not event.is_virtual %}
-                <meta property="schema:address" content="{{ event.location.address }}"/>
-                {% elif event.join_url %}
-                <meta property="schema:url" content="{{ event.join_url }}"/>
-                {% endif %}
             </div>
         </div>
         <div class="when">
@@ -44,6 +33,4 @@
             {% endif %}
         </div>
     </a>
-    {# description is recommended for schema.org #}
-    <div style="display:none" property="schema:description">{{ event.search_description }}</div>
 </div>

--- a/cdhweb/people/models.py
+++ b/cdhweb/people/models.py
@@ -632,7 +632,7 @@ class PeopleLandingPageArchived(LandingPage):
 class PeopleCategoryPage(BaseLandingPage, SidebarNavigationMixin, RoutablePageMixin):
     """Landing Page for categeory of people i.e. staff, students, affiliates, executive committee"""
 
-    subpage_types = [Profile]
+    subpage_types = []
 
     template_name = "people/people_category_page.html"
 
@@ -810,7 +810,7 @@ class PeopleCategoryPage(BaseLandingPage, SidebarNavigationMixin, RoutablePageMi
 
 
 class PeopleLandingPage(StandardHeroMixin, Page):
-    subpage_types = [PeopleCategoryPage]
+    subpage_types = [Profile, PeopleCategoryPage]
 
     template_name = "people/people_landing_page.html"
 

--- a/cdhweb/people/wagtail_hooks.py
+++ b/cdhweb/people/wagtail_hooks.py
@@ -51,6 +51,7 @@ class ProfileAdmin(ThumbnailMixin, ModelAdmin):
     search_fields = ("title", "body")
     ordering = ("title",)
     thumb_image_field_name = "image"
+    exclude_from_explorer = True
 
 
 class LinkTypeAdmin(ModelAdmin):

--- a/cdhweb/projects/forms.py
+++ b/cdhweb/projects/forms.py
@@ -10,21 +10,21 @@ class ProjectFiltersForm(forms.Form):
 
     q = forms.CharField(required=False, label="Keyword")
     method = forms.ModelChoiceField(
-        ProjectMethod.objects.all(),
+        ProjectMethod.objects.filter(projects__isnull=False).distinct(),
         empty_label="--Select--",
         required=False,
         blank=True,
         label="Method/Approach",
     )
     field = forms.ModelChoiceField(
-        ProjectField.objects.all(),
+        ProjectField.objects.filter(projects__isnull=False).distinct(),
         empty_label="--Select--",
         required=False,
         blank=True,
         label="Field of Study",
     )
     role = forms.ModelChoiceField(
-        ProjectRole.objects.all(),
+        ProjectRole.objects.filter(projects__isnull=False).distinct(),
         empty_label="--Select--",
         required=False,
         blank=True,

--- a/templates/includes/event_hero.html
+++ b/templates/includes/event_hero.html
@@ -19,23 +19,21 @@
             <a href="{{ self.get_ical_url }}">Add to calendar</a>
         </p>
 
-        {# Much of this schema is ported over from the old event template #}
         {% if self.location %}
             <div
                 class="event-hero__location"
                 property="schema:location"
                 typeof="{% if self.location.name %}schema:VirtualLocation{% else %}schema:Place{% endif %}"
             >
-                <span property="schema:name">{{ self.location.name }}</span>
+                <span>{{ self.location.name }}</span>
                 {% if not self.location.name == "Virtual" %}
                     <div
-                        property="schema:address"
                         {% if self.location.name == self.location.address %}style="display:none"{% endif %}
                     >
                         {{ self.location.address }}
                     </div>
                 {% elif self.join_url %}
-                    <div property="schema:url" style="display:none">{{ page.join_url }}</div>
+                    <div style="display:none">{{ page.join_url }}</div>
                 {% endif %}
             </div>
         {% endif %}


### PR DESCRIPTION
**Associated Issue(s):** CDH-54

### Changes in this PR

- Exclude people pages from the Wagtail page explorer, as they have their own menu item (for the modeladmin)
- Allow creation of Profile pages under the People landing page

