### PR TITLE
[HOTFIX] Allow person profile pages to be created where they belong

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.1.1
+-----
+- Allow person profile pages to be created where they belong
+- Return to excluding profile pages from the page explorer
+
 4.1.0
 -----
 - Frontend dependency updates, and related fixes

--- a/cdhweb/__init__.py
+++ b/cdhweb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.1.0"
+__version__ = "4.1.1"
 
 
 # context processor to add version to the template environment; can be

--- a/cdhweb/people/models.py
+++ b/cdhweb/people/models.py
@@ -632,7 +632,7 @@ class PeopleLandingPageArchived(LandingPage):
 class PeopleCategoryPage(BaseLandingPage, SidebarNavigationMixin, RoutablePageMixin):
     """Landing Page for categeory of people i.e. staff, students, affiliates, executive committee"""
 
-    subpage_types = [Profile]
+    subpage_types = []
 
     template_name = "people/people_category_page.html"
 
@@ -810,7 +810,7 @@ class PeopleCategoryPage(BaseLandingPage, SidebarNavigationMixin, RoutablePageMi
 
 
 class PeopleLandingPage(StandardHeroMixin, Page):
-    subpage_types = [PeopleCategoryPage]
+    subpage_types = [Profile, PeopleCategoryPage]
 
     template_name = "people/people_landing_page.html"
 

--- a/cdhweb/people/wagtail_hooks.py
+++ b/cdhweb/people/wagtail_hooks.py
@@ -51,6 +51,7 @@ class ProfileAdmin(ThumbnailMixin, ModelAdmin):
     search_fields = ("title", "body")
     ordering = ("title",)
     thumb_image_field_name = "image"
+    exclude_from_explorer = True
 
 
 class LinkTypeAdmin(ModelAdmin):


### PR DESCRIPTION
**Associated Issue(s):** #

### Changes in this PR
- Allow person profile pages to be created where they belong
- Return to excluding profile pages from the page explorer
- Version bump to 4.1.1

### Notes

- To be released as a hotfix soonish