### PR TITLE
CDH-118 Add breadcrumbs to search page

### DIFF
--- a/cdhweb/pages/views.py
+++ b/cdhweb/pages/views.py
@@ -100,7 +100,26 @@ class SiteSearchView(ListView, FormMixin):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update({"page_title": self.page_title})
+        print("**********")
+        print(context)
+
+        # Get the HomePage for breadcrumbs
+        from cdhweb.pages.models import HomePage
+
+        home_page = HomePage.objects.first()
+
+        context.update(
+            {
+                "page_title": self.page_title,
+                "breadcrumbs": [home_page]
+                if home_page
+                else [],  # HomePage for breadcrumbs
+                "page": {  # mock page object for breadcrumbs
+                    "title": "Search",
+                    "short_title": "Search",
+                },
+            }
+        )
         return context
 
 

--- a/cdhweb/pages/views.py
+++ b/cdhweb/pages/views.py
@@ -100,8 +100,6 @@ class SiteSearchView(ListView, FormMixin):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        print("**********")
-        print(context)
 
         # Get the HomePage for breadcrumbs
         from cdhweb.pages.models import HomePage

--- a/templates/cdhpages/search.html
+++ b/templates/cdhpages/search.html
@@ -6,6 +6,8 @@
 {% block bodyclass %}search{% endblock bodyclass %}
 
 {% block main %}
+    {% include 'includes/breadcrumbs.html' with breadcrumbs=breadcrumbs current_page=page %}
+    
     <div class="search-page grid-standard content-width">
         <h1>
             {% if form.q.value %}


### PR DESCRIPTION
**Associated Issue(s):** https://springload-nz.atlassian.net/browse/CDH-118

### Changes in this PR
_Include all key changes in this pull request_

Adding breadcrumbs to the search page

### Notes
_Include any additional notes that will help in the reviewing of this pull request_

Assuming the flow will always be Home > Search

<img width="1472" height="649" alt="image" src="https://github.com/user-attachments/assets/b76cb8f0-6558-43f4-b152-2e5ab529a04b" />


