### PR TITLE
turn add to calendar link into button

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,11 +11,6 @@ CHANGELOG
 - Allow person profile pages to be created where they belong
 - Return to excluding profile pages from the page explorer
 
-4.1.1
------
-- Allow person profile pages to be created where they belong
-- Return to excluding profile pages from the page explorer
-
 4.1.0
 -----
 - Frontend dependency updates, and related fixes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ CHANGELOG
 - Allow person profile pages to be created where they belong
 - Return to excluding profile pages from the page explorer
 
+4.1.1
+-----
+- Allow person profile pages to be created where they belong
+- Return to excluding profile pages from the page explorer
+
 4.1.0
 -----
 - Frontend dependency updates, and related fixes

--- a/cdhweb/static_src/global/components/event-hero.scss
+++ b/cdhweb/static_src/global/components/event-hero.scss
@@ -94,8 +94,12 @@ Event hero. Similar to standard hero. Key differences:
 }
 
 .event-hero__add-to-calendar {
-  margin: 4px 0 16px;
+  gap: 8px;
   font-size: fn.rem(14);
+  margin-block-start: 24px; // mobile first
+  @include mx.xl {
+    margin-block-start: 40px; // everything else
+  }
 }
 
 .event-hero__location {

--- a/cdhweb/static_src/global/components/event-hero.scss
+++ b/cdhweb/static_src/global/components/event-hero.scss
@@ -101,7 +101,6 @@ Event hero. Similar to standard hero. Key differences:
 
   @include mx.sm {
     flex-direction: row;
-    gap: 16px;
   }
 
   @include mx.xl {

--- a/cdhweb/static_src/global/components/event-hero.scss
+++ b/cdhweb/static_src/global/components/event-hero.scss
@@ -97,7 +97,7 @@ Event hero. Similar to standard hero. Key differences:
   display: flex;
   flex-direction: column;
   gap: 16px;
-  margin-block-start: 24px; // mobile first
+  margin-block-start: 24px;
 
   @include mx.sm {
     flex-direction: row;
@@ -105,7 +105,7 @@ Event hero. Similar to standard hero. Key differences:
   }
 
   @include mx.xl {
-    margin-block-start: 40px; // everything else
+    margin-block-start: 40px;
   }
 }
 

--- a/cdhweb/static_src/global/components/event-hero.scss
+++ b/cdhweb/static_src/global/components/event-hero.scss
@@ -93,10 +93,17 @@ Event hero. Similar to standard hero. Key differences:
   margin: 16px 0 0;
 }
 
-.event-hero__add-to-calendar {
-  gap: 8px;
-  font-size: fn.rem(14);
+.event-hero__buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
   margin-block-start: 24px; // mobile first
+
+  @include mx.sm {
+    flex-direction: row;
+    gap: 16px;
+  }
+
   @include mx.xl {
     margin-block-start: 40px; // everything else
   }

--- a/cdhweb/static_src/images/sprites_src/two-tone/rsvp.svg
+++ b/cdhweb/static_src/images/sprites_src/two-tone/rsvp.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+  <path fill="var(--icon-accent-color, #00edff)" d="M18.44 4.06h-15v15h15v-15Z" />
+  <path fill="var(--icon-accent-color, #00edff)"
+    d="M19.06 19.69H2.81V3.44h16.25v16.25Zm-15-1.25h13.75V4.69H4.06v13.75Z" />
+  <path fill="#fff" d="M16.56 2.19h-15v15h15v-15Z" />
+  <path fill="var(--icon-color, #414042)" d="M17.19 17.81H.94V1.56h16.25v16.25Zm-15-1.25h13.75V2.81H2.19v13.75Z" />
+  <path fill="var(--icon-color, #414042)"
+    d="M16.56 5.63h-15v1.25h15V5.63Zm-8.13 6.32a.06.06 0 0 1-.08 0l-1.62-1.73-1.1 1.19 2.76 2.96 4.42-4.75-1.1-1.18-3.28 3.51ZM5.63 0H4.38v3.75h1.25V0Zm8.15 0h-1.25v3.75h1.25V0Z" />
+</svg>

--- a/templates/includes/event_hero.html
+++ b/templates/includes/event_hero.html
@@ -15,11 +15,19 @@
                 <time datetime="{{ self.end_time|date:'c' }}">{{ self.end_time|date:"M d g:i a" }}</time>
             {% endif %}
         </p>
-        <p class="event-hero__add-to-calendar">
+        
+        <p class="event-hero__buttons">
             <a class="sk-btn sk-btn--primary" href="{{ self.get_ical_url }}">
                 Add to calendar
                 {% include 'includes/svg.html' with sprite="two-tone" svg="cal" %}
             </a>
+
+            {% if self.rsvp_url %}
+            <a class="sk-btn sk-btn--secondary" href="{{ self.rsvp_url }}">
+                {{ self.rsvp_text }}
+                {% include 'includes/svg.html' with sprite="two-tone" svg="rsvp" %}
+            </a>
+            {% endif %}
         </p>
 
         {% if self.location %}

--- a/templates/includes/event_hero.html
+++ b/templates/includes/event_hero.html
@@ -16,7 +16,10 @@
             {% endif %}
         </p>
         <p class="event-hero__add-to-calendar">
-            <a href="{{ self.get_ical_url }}">Add to calendar</a>
+            <a class="sk-btn sk-btn--primary" href="{{ self.get_ical_url }}">
+                Add to calendar
+                {% include 'includes/svg.html' with sprite="two-tone" svg="cal" %}
+            </a>
         </p>
 
         {% if self.location %}


### PR DESCRIPTION
**Associated Issue(s):** https://springload-nz.atlassian.net/browse/CDH-86

### Changes in this PR
_Include all key changes in this pull request_

Turning 'add to calendar' link into button. Also adding rsvp button if it exists in the cms

<img width="1053" height="790" alt="image" src="https://github.com/user-attachments/assets/de9c0c2a-5526-42d0-89cd-39f028333b0b" />

<img width="441" height="565" alt="image" src="https://github.com/user-attachments/assets/fc6d5565-71c3-4775-9aa7-b53755543826" />

