### PR TITLE
CDH-62 Add category label to event page

### DIFF
--- a/cdhweb/static_src/global/components/event-hero.scss
+++ b/cdhweb/static_src/global/components/event-hero.scss
@@ -59,6 +59,8 @@ Event hero. Similar to standard hero. Key differences:
   grid-area: t;
   font-size: fn.rem(16);
   line-height: 1.125;
+  display: flex; // to support visual re-ordering (tag before h1)
+  flex-direction: column;
 
   :where(h1) {
     margin-block-start: var(--title-top-space);
@@ -86,6 +88,12 @@ Event hero. Similar to standard hero. Key differences:
       margin-block-start: 40px;
     }
   }
+}
+
+.event-hero__type-tag {
+  justify-self: start;
+  align-self: start;
+  order: -1; // visually before h1
 }
 
 .event-hero__date {

--- a/templates/includes/event_hero.html
+++ b/templates/includes/event_hero.html
@@ -4,6 +4,9 @@
 
     <div class="event-hero__text">
         <h1>{{ self.title}}</h1>
+        {% if self.type %}
+            <div class="event-hero__type-tag tag tag--dark tag--bigger">{{ self.type }}</div>
+        {% endif %}
 
         <p class="event-hero__date">
             {# Display date differently depending on if it spans multiple days #}


### PR DESCRIPTION
**Associated Issue(s):** https://springload-nz.atlassian.net/browse/CDH-62

### Changes in this PR
_Include all key changes in this pull request_

Adding category label event details page.

### Notes
_Include any additional notes that will help in the reviewing of this pull request_

Has already been added to blog page in previous PR

<img width="950" height="632" alt="image" src="https://github.com/user-attachments/assets/5386c00d-ee58-48df-8e4e-a34141210199" />

