### PR TITLE
[CDH-126] Update/revert featured tile style

### DIFF
--- a/cdhweb/static_src/global/components/tiles.scss
+++ b/cdhweb/static_src/global/components/tiles.scss
@@ -52,60 +52,16 @@
 }
 
 .tile {
-  --border-color: var(--tile-border-color, var(--color-brand-100));
   display: grid;
   position: relative; // for whole-tile click pseudo element
   grid-template-rows: auto 1fr;
 }
 
 .tile--featured {
-  --tile-border-color: var(--color-grey-100);
-}
+  grid-column: 1 / -1;
 
-// Extra wrapper required for container query
-.featured-tile-wrapper {
-  @supports (container-name: test) {
-    container-type: inline-size;
-    container-name: featured-tile;
-
-    // The no. of cols the wrapper has (.tiles__list) is based on *its* width, i.e.
-    // not by breakpoint. So we don't know *exactly* when the grid layout will go
-    // from 1 col to 2. It happens somewhere between `sm` and `md`. BUT we can be
-    // confident that from `md`, there will be at least 2 cols, so we can set the
-    // featured tile to span 2 cols from then (doing so when there is only 1 column
-    // causes layout bugs.
-    grid-column: 1 / -1;
-
-    @include mx.lg {
-      grid-column: span 2;
-    }
-  }
-}
-
-@container featured-tile (min-width: #{fn.rem(400)}) {
-  .tile--featured {
-    grid-template-rows: 1fr;
-    grid-template-columns: 0.9fr 1fr;
-    height: 100%;
-    min-height: fn.rem(250);
-
-    .tile__img-wrapper {
-      grid-column: 1;
-      grid-row: 1;
-      height: unset;
-      aspect-ratio: unset;
-    }
-    .tile__text {
-      grid-column: 2;
-      grid-row: 1;
-      border: 8px solid var(--border-color);
-      border-left: none;
-      padding-left: 40px;
-      align-content: end;
-    }
-    .tile__tag {
-      grid-column: 1 / -1;
-    }
+  @include mx.lg {
+    grid-column: span 2;
   }
 }
 
@@ -113,7 +69,7 @@
   grid-row: 2;
   grid-column: 1;
   background-color: var(--color-white);
-  border: 8px solid var(--border-color);
+  border: 8px solid var(--color-brand-100);
   border-top: none;
   padding: 24px 12px;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4885,9 +4885,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "version": "1.0.30001753",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001753.tgz",
+      "integrity": "sha512-Bj5H35MD/ebaOV4iDLqPEtiliTN29qkGtEHCwawWn4cYm+bPJM2NsaP30vtZcnERClMzp52J4+aw2UNbK4o+zw==",
       "dev": true,
       "funding": [
         {

--- a/templates/blog/blog_landing_page.html
+++ b/templates/blog/blog_landing_page.html
@@ -37,9 +37,7 @@
 
           <div class="tiles__list">
             {% if featured_post %}
-              <div class="featured-tile-wrapper">
-                {% include 'cdhpages/blocks/tile.html' with internal_page=featured_post tile_type='internal_page_tile' is_featured=True %}
-              </div>
+              {% include 'cdhpages/blocks/tile.html' with internal_page=featured_post tile_type='internal_page_tile' is_featured=True %}
             {% endif %}
             {% for post in posts %}
               {% include 'cdhpages/blocks/tile.html' with internal_page=post tile_type='internal_page_tile' %}

--- a/templates/projects/projects_landing_page.html
+++ b/templates/projects/projects_landing_page.html
@@ -76,9 +76,7 @@
 
             {% if results %}
                 {% if featured_project %}
-                    <div class="featured-tile-wrapper">
-                        {% include 'cdhpages/blocks/tile.html' with internal_page=featured_project tile_type='internal_page_tile' is_featured=True has_component_title=True %}
-                    </div>
+                    {% include 'cdhpages/blocks/tile.html' with internal_page=featured_project tile_type='internal_page_tile' is_featured=True has_component_title=True %}
                 {% endif %}
                 {% for project in results %}
                     {% include 'cdhpages/blocks/tile.html' with internal_page=project tile_type='internal_page_tile' has_component_title=True %}


### PR DESCRIPTION
**Associated Issue(s):** 
https://springload-nz.atlassian.net/browse/CDH-126

### Changes in this PR

During part of the recent design QA changes (https://github.com/Princeton-CDH/cdh-web/pull/460), we found that the "featured" tile variant didn't match the design. This was due to a template/CSS bug. So during that tranche of work, I fixed it. 

However, CDH decided they actually preferred it the way it was before these fixes – due to e.g. the tile's image aspect ratio being more consistent/predictable. So this PR removes the CSS code which applied layout changes, and keeps just the "occupy 2 columns when space permits" part of the featured tile layout.

