### PR TITLE
[CDH-95] Remove "featured" styling from pinned blog/article tiles

### DIFF
--- a/templates/blog/blog_landing_page.html
+++ b/templates/blog/blog_landing_page.html
@@ -37,7 +37,12 @@
 
           <div class="tiles__list">
             {% if featured_post %}
-              {% include 'cdhpages/blocks/tile.html' with internal_page=featured_post tile_type='internal_page_tile' is_featured=True %}
+              {% comment %}
+                NOTE: 
+                We're not using `is_featured=True` for blog/article tiles. We only use that style on `project` tiles.
+                We still want to 'pin' the featured post to the top though.
+              {% endcomment %}
+              {% include 'cdhpages/blocks/tile.html' with internal_page=featured_post tile_type='internal_page_tile' %}
             {% endif %}
             {% for post in posts %}
               {% include 'cdhpages/blocks/tile.html' with internal_page=post tile_type='internal_page_tile' %}


### PR DESCRIPTION
**Associated Issue(s):** 
https://springload-nz.atlassian.net/browse/CDH-95

### Changes in this PR
- If a blog/news article is 'featured', keep it pinned to the top of the tile list (current behaviour) but don't change it to the larger "featured" style, like how a project tile would look.

## before 
<img width="1222" height="766" alt="Screenshot 2026-02-20 at 9 13 09 AM" src="https://github.com/user-attachments/assets/12b53f6a-3a0f-42ac-8f93-df165d64346f" />


## after
<img width="1231" height="507" alt="Screenshot 2026-02-20 at 9 12 58 AM" src="https://github.com/user-attachments/assets/ca020918-fe83-4b80-b5a7-3534c622fe86" />

